### PR TITLE
Added build_script file to build images

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ You can also use the build script in the folder build_scripts to build the Docke
 
 ::
 
-    python docker_image_creator.py path_to_wheel_binary gpu|cpu framework_version python_version
+    python docker_image_creator.py <path_to_wheel_binary> <gpu|cpu> <framework_version> <python_version>
 
 ::
 
@@ -180,15 +180,15 @@ To use nvidia-docker instead of docker to build the image, run the command:
 
 ::
 
-     python docker_image_creator.py path_to_wheel_binary gpu|cpu framework_version python_version --nvidia-docker
+     python docker_image_creator.py <path_to_wheel_binary> <gpu|cpu> <framework_version> <python_version> --nvidia-docker
 
 ::
 
-The default repository the final image will be placed in is preprod-tensorflow. To set the repository to a custom value, run the command:
+The default repository the final image will be placed in is 'preprod-tensorflow'. To set the repository to a custom value, run the command:
 
 ::
 
-    python docker_image_creator.py path_to_wheel_binary gpu|cpu framework_version python_version --final-image-repository repository_name
+    python docker_image_creator.py <path_to_wheel_binary> <gpu|cpu> <framework_version> <python_version> --final-image-repository <repository_name>
 
 ::
 
@@ -196,7 +196,7 @@ The default tag the final image will have is 'framework_version-processor_type-p
 
 ::
 
-    python docker_image_creator.py path_to_wheel_binary gpu|cpu framework_version python_version --final-image-tags tag1 tag2 ...
+    python docker_image_creator.py <path_to_wheel_binary> <gpu|cpu> <framework_version> <python_version> --final-image-tags <tag1> <tag2> ...
 
 Running the tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -167,9 +167,6 @@ The dockerfiles for 1.4 and 1.5 build from source instead, so when building thos
 
 Build scripts
 ~~~~~~~~~~~~~
-To use the build script, you need to have nvidia-docker installed.
-
-::
 
 To build the docker images you can also use the build script in the folder build_scripts. To run this program, execute the command in the build scripts directory:
 
@@ -177,7 +174,9 @@ To build the docker images you can also use the build script in the folder build
 
     python docker_image_creator.py link_to_dockerfile_github link_to_optimized_binary 'gpu'|'cpu' framework_version python_version
 
+::
 
+To use the build script, you need to have nvidia-docker installed.
 
 Running the tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,16 @@ The dockerfiles for 1.4 and 1.5 build from source instead, so when building thos
     # GPU
     docker build -t preprod-tensorflow:1.4.1-gpu-py2 -f Dockerfile.gpu .
 
+Build scripts
+~~~~~~~~~~~~~
+
+To use the build script, you need to have nvidia-docker installed.
+
+To build the docker images you can also use the build script in the folder build_scripts. To run this program, execute the command in the build scripts directory:
+
+::
+    python docker_image_creator.py link_to_dockerfile_github link_to_optimized_binary 'gpu'|'cpu' framework_version python_version
+::
 
 Running the tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -168,15 +168,19 @@ The dockerfiles for 1.4 and 1.5 build from source instead, so when building thos
 Build scripts
 ~~~~~~~~~~~~~
 
-To build the docker images you can also use the build script in the folder build_scripts. To run this program, execute the command in the build scripts directory:
+You can also use the build script in the folder build_scripts to build the Docker images. To run this program, execute the command:
 
 ::
 
-    python docker_image_creator.py link_to_optimized_binary 'gpu'|'cpu' framework_version python_version
+    python docker_image_creator.py link_to_optimized_binary gpu|cpu framework_version python_version
 
 ::
 
-To use the build script, you need to have nvidia-docker installed.
+To use nvidia-docker instead of docker to build the image, run the command:
+
+::
+
+    python docker_image_creator.py link_to_optimized_binary gpu|cpu framework_version python_version --nvidia-docker
 
 Running the tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ To build the docker images you can also use the build script in the folder build
 
 ::
 
-    python docker_image_creator.py link_to_dockerfile_github link_to_optimized_binary 'gpu'|'cpu' framework_version python_version
+    python docker_image_creator.py link_to_optimized_binary 'gpu'|'cpu' framework_version python_version
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -167,14 +167,17 @@ The dockerfiles for 1.4 and 1.5 build from source instead, so when building thos
 
 Build scripts
 ~~~~~~~~~~~~~
-
 To use the build script, you need to have nvidia-docker installed.
+
+::
 
 To build the docker images you can also use the build script in the folder build_scripts. To run this program, execute the command in the build scripts directory:
 
 ::
+
     python docker_image_creator.py link_to_dockerfile_github link_to_optimized_binary 'gpu'|'cpu' framework_version python_version
-::
+
+
 
 Running the tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ You can also use the build script in the folder build_scripts to build the Docke
 
 ::
 
-    python docker_image_creator.py link_to_optimized_binary gpu|cpu framework_version python_version
+    python docker_image_creator.py path_to_wheel_binary gpu|cpu framework_version python_version
 
 ::
 
@@ -180,7 +180,23 @@ To use nvidia-docker instead of docker to build the image, run the command:
 
 ::
 
-    python docker_image_creator.py link_to_optimized_binary gpu|cpu framework_version python_version --nvidia-docker
+     python docker_image_creator.py path_to_wheel_binary gpu|cpu framework_version python_version --nvidia-docker
+
+::
+
+The default repository the final image will be placed in is preprod-tensorflow. To set the repository to a custom value, run the command:
+
+::
+
+    python docker_image_creator.py path_to_wheel_binary gpu|cpu framework_version python_version --final-image-repository repository_name
+
+::
+
+The default tag the final image will have is 'framework_version-processor_type-py_version'. To customize the tag(s) set, run the command:
+
+::
+
+    python docker_image_creator.py path_to_wheel_binary gpu|cpu framework_version python_version --final-image-tags tag1 tag2 ...
 
 Running the tests
 -----------------

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     DOCKER = 'nvidia-docker' if args.nvidia_docker else DOCKER
 
     # Sets PATH_TO_SCRIPT so that command can be run from anywhere
-    PATH_TO_SCRIPT = os.path.join('.', '/'.join(sys.argv[0].split('/')[:-1]))
+    PATH_TO_SCRIPT = os.path.dirname(os.path.abspath(sys.argv[0]))
 
     # Build image
     create_docker_image(args.optimized_binary_link, args.processor_type, args.framework_version, args.python_version)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -10,27 +10,28 @@ import shutil
 import subprocess
 import sys
 
-## GLOBALS
-DOCKER = 'docker' # Stores which type of DOCKER to use, nvidia-docker or docker
-PATH_TO_SCRIPT = ''  # Stores route the user takes to build scripts directory
-
-def create_docker_image(optbin_link, processor, framework_version, python_version):
-    """ Function builds a docker image with the TF optimized binary
+def create_docker_image(processor, framework_version, python_version, optbin_path):
+    """ Function builds a docker image
 
     Args:
-        optbin_link (str): link to where the optimized binary is
         processor (str): gpu or cpu
         framework_version (str): tensorflow version i.e 1.6.0
         python_version (str): (i.e. 3.6.5 or 2.7.4)
+        optbin_path (str): link to where the optimized binary is.
     """
     # Initialize commonly used variables
     py_v = 'py{}'.format(python_version.split('.')[0]) # i.e. py2
 
-    # Get optimized binary - and put in final docker image repo
-    print('Getting optimized binary...')
-    optbin_filename = 'tensorflow-{}-cp27-cp27mu-manylinux1_x86_64.whl'.format(framework_version)
-    with open('{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, optbin_filename), 'wb') as optbin_file:
-        subprocess.call(['curl', optbin_link], stdout=optbin_file)
+    # If necessary, get optimized binary and put in final docker image repo
+    if optbin_path:
+        print('Getting optimized binary...')
+        # Check if it is local or remote
+        optbin_filename = 'tensorflow-{}-{}-binary.whl'.format(framework_version, processor)
+        if os.path.isfile(optbin_path):
+            shutil.copyfile(optbin_filename, '{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, output_filename))
+        else:
+            with open('{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, optbin_filename), 'wb') as optbin_file:
+                subprocess.call(['curl', optbin_link], stdout=optbin_file)
 
     # Build base image
     print('Building base image...')
@@ -41,28 +42,33 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     #  Build final image
     print('Building final image...')
     subprocess.call(['python', 'setup.py', 'sdist'], cwd='{}/..'.format(PATH_TO_SCRIPT))
-    output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0] # use glob to use regex
+    output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0]
     output_filename = output_file.split('/')[-1]
     shutil.copyfile(output_file, '{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, output_filename))
-    subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v), \
-                    '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename), \
-                    '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
+    if optbin_path:
+        subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v),
+                        '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename),
+                        '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
+    else:
+        subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v),
+                        '--build-arg', 'py_version={}'.format(py_v[-1]), '-f', 'Dockerfile.{}'.format(processor), '.'],
+                        cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
 
 if __name__ == '__main__':
     # Parse command line options
     parser = argparse.ArgumentParser(description='Build Sagemaker TensorFlow Docker Images')
-    parser.add_argument('optimized_binary_link', help='link to place with optimized binary')
     parser.add_argument('processor_type', choices=['cpu', 'gpu'], help='gpu if you would like to use GPUs or cpu')
     parser.add_argument('framework_version', help='TensorFlow framework version (i.e. 1.8.0)')
     parser.add_argument('python_version', help='Python version to be used (i.e. 2.7.0)')
+    parser.add_argument('--optimized_binary_path', default=None, help='path to optimized binary')
     parser.add_argument('--nvidia-docker', action='store_true', help="Enables nvidia-docker usage over docker usage")
     args = parser.parse_args()
 
     # Set value for docker
-    DOCKER = 'nvidia-docker' if args.nvidia_docker else DOCKER
+    DOCKER = 'nvidia-docker' if args.nvidia_docker else 'docker'
 
     # Sets PATH_TO_SCRIPT so that command can be run from anywhere
     PATH_TO_SCRIPT = os.path.dirname(os.path.abspath(sys.argv[0]))
 
     # Build image
-    create_docker_image(args.optimized_binary_link, args.processor_type, args.framework_version, args.python_version)
+    create_docker_image(args.processor_type, args.framework_version, args.python_version, args.optimized_binary_path)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -6,60 +6,47 @@ Run the command:
 import argparse
 import os
 
-def create_docker_image(dockerfile_github_link, optbin_link, processor, framework_version, python_version):
+def create_docker_image(optbin_link, processor, framework_version, python_version):
     """
     Function builds a docker image with the TF optimized binary
 
-    :param dockerfile_github_link: link to docker file repo
+    Assumptions:
+        1. Script needs to be run inside of the build_scripts files
+
     :param optbin_link: link to where the optimized binary is
     :param processor: gpu or cpu
     :param framework_version: tensorflow version i.e 1.6.0
     :param python_version: version of python to build container with i.e. 3.6.5 or 2.7.4
-    :return: final built imageid
     """
-    # 0.) Initialize some commonly used variables
-    dockerfile_repo_name = dockerfile_github_link.split('/')[-1].split('.')[0]
+    # 1.) Initialize some commonly used variables
     pyV = "py{}".format(python_version.split('.')[0]) # i.e. py2
     framework = "tensorflow"
-    # 1.) Clone dockerfile repo from Github
-    print("Cloning dockerfile repo...")
-    os.system("git clone {}".format(dockerfile_github_link))
-    # 2.) Get optimized binary - need to better parametrize the name
+    # 2.) Get optimized binary - and put in final docker image repo
     print("Getting optimized binary...")
-    optbin_filename = "{}-{}-cp27-cp27mu-manylinux1_x86_64.whl".format(framework, framework_version) # just a tmp file name
-    os.system("curl {} > {}".format(optbin_link, optbin_filename))
+    optbin_filename = "{}-{}-cp27-cp27mu-manylinux1_x86_64.whl".format(framework, framework_version)
+    os.system("curl {} > ../docker/{}/final/{}/{}".format(optbin_link, framework_version, pyV, optbin_filename))
     # 3.) Build base image
     print("Building base image...")
     image_name = "{}-base:{}-{}-{}".format(framework, framework_version, processor,  pyV)
-    base_docker_path = "docker/{}/base/Dockerfile.{}".format(framework_version, processor)
-    os.system("sudo nvidia-docker build -t {} -f {}/{} .".format(image_name, dockerfile_repo_name, base_docker_path))
+    base_docker_path = "../docker/{}/base/Dockerfile.{}".format(framework_version, processor)
+    os.system("sudo nvidia-docker build -t {} -f {} .".format(image_name, base_docker_path))
     # 4.) Build final image
     print("Building final image...")
-    os.chdir("{}".format(dockerfile_repo_name))
+    os.chdir("..")
     os.system("python setup.py sdist")
-    os.system("cp dist/sagemaker_tensorflow_container-1.0.0.tar.gz docker/{}/final/{}".format(framework_version, pyV))
-    os.system("cp ../{}  docker/{}/final/{}".format(optbin_filename, framework_version, pyV))
+    os.system("cp dist/sagemaker_tensorflow_container-*.tar.gz docker/{}/final/{}".format(framework_version, pyV))
     os.chdir("docker/{}/final/{}".format(framework_version, pyV))
     os.system \
         ("sudo nvidia-docker build -t preprod-{}:{}-{}-{} --build-arg py_version={} --build-arg framework_installable={}  -f Dockerfile.{} .".format
             (framework, framework_version, processor, pyV, pyV[-1], optbin_filename, processor))
-    # 5.) Clean everything up
-    print("Cleaning up...")
-    os.chdir("../../../../..")
-    os.system("sudo rm -r {} {}".format(optbin_filename, dockerfile_repo_name))
-    # 6.) Return image id
-    image_id = os.popen("sudo nvidia-docker images preprod-{}:{}-{}-{} -q".format(framework, framework_version, processor, python_version)).read()
-    return image_id[:-1] # removes endline
-
 
 if __name__ == "__main__":
     # Parse command line options
     parser = argparse.ArgumentParser()
-    parser.add_argument("dockerfile_github_link", help="link to github containing docker files")
     parser.add_argument("optimized_binary_link", help="link to place with optimized binary")
     parser.add_argument("processor_type", help="gpu if you would like to use GPUs or cpu")
     parser.add_argument("framework_version", help="Tensorflow framework version (i.e. 1.8.0)")
     parser.add_argument("python_version", help="Python version to be used (i.e. 2.7.0)")
     args = parser.parse_args()
     # Build image
-    create_docker_image(args.dockerfile_github_link, args.optimized_binary_link, args.processor_type, args.framework_version, args.python_version)
+    create_docker_image(args.optimized_binary_link, args.processor_type, args.framework_version, args.python_version)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -46,6 +46,7 @@ def create_docker_image(processor, framework_version, python_version, optbin_pat
     output_filename = output_file.split('/')[-1]
     shutil.copyfile(output_file, '{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, output_filename))
     if optbin_path:
+        print("Building with binary")
         subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v),
                         '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename),
                         '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
@@ -60,7 +61,7 @@ if __name__ == '__main__':
     parser.add_argument('processor_type', choices=['cpu', 'gpu'], help='gpu if you would like to use GPUs or cpu')
     parser.add_argument('framework_version', help='TensorFlow framework version (i.e. 1.8.0)')
     parser.add_argument('python_version', help='Python version to be used (i.e. 2.7.0)')
-    parser.add_argument('--optimized_binary_path', default=None, help='path to optimized binary')
+    parser.add_argument('--optimized-binary-path', default=None, help='path to optimized binary')
     parser.add_argument('--nvidia-docker', action='store_true', help="Enables nvidia-docker usage over docker usage")
     args = parser.parse_args()
 

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -25,8 +25,8 @@ def create_docker_image(processor, framework_version, python_version, optbin_pat
     # If necessary, get optimized binary and put in final docker image repo
     if optbin_path:
         print('Getting optimized binary...')
-        # Check if it is local or remote
-        optbin_filename = 'tensorflow-{}-{}-binary.whl'.format(framework_version, processor)
+        # Name of file will be the end of the path
+        optbin_filename = optbin_path.split('/')[-1]
         if os.path.isfile(optbin_path):
             shutil.copyfile(optbin_filename, '{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, output_filename))
         else:

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -4,7 +4,7 @@
         python docker_image_creator.py optimized_binary_link gpu|cpu tensorflow_version python_version
 """
 import argparse
-import glob
+import os
 import shutil
 import subprocess
 import sys

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -1,59 +1,68 @@
+""" Script to create Sagemaker TensorFlow Docker image
+    Run the command:
+        python docker_image_creator.py optimized_binary_link gpu|cpu tensorflow_version python_version
+
 """
-Script to run docker image creation
-Run the command:
-    python docker_image_creator.py optimized_binary_link gpu|cpu tensorflow_version python_version
-"""
+
 import argparse
-import os
+import glob
+import subprocess
 import sys
 
 ## GLOBALS
-# Allows user to run script anywhere
-BASE_PATH = ""
+DOCKER = 'docker' # Stores which type of DOCKER to use, nvidia-docker or docker
+PATH_TO_SCRIPT = ''  # Stores route the user takes to build scripts directory
 
 def create_docker_image(optbin_link, processor, framework_version, python_version):
-    """
-    Function builds a docker image with the TF optimized binary
+    """ Function builds a docker image with the TF optimized binary
 
-    :param optbin_link: link to where the optimized binary is
-    :param processor: gpu or cpu
-    :param framework_version: tensorflow version i.e 1.6.0
-    :param python_version: version of python to build container with i.e. 3.6.5 or 2.7.4
+    Args:
+        param1 (str): optbin_link - link to where the optimized binary is
+        param2 (str): processor - gpu or cpu
+        param3 (str): framework_version - tensorflow version i.e 1.6.0
+        param4 (str): python_version (i.e. 3.6.5 or 2.7.4)
+
     """
-    # 1.) Initialize some commonly used variables
-    pyV = "py{}".format(python_version.split('.')[0]) # i.e. py2
-    framework = "tensorflow"
+    # 1.) Initialize commonly used variables
+    py_v = 'py{}'.format(python_version.split('.')[0]) # i.e. py2
+
     # 2.) Get optimized binary - and put in final docker image repo
-    print("Getting optimized binary...")
-    optbin_filename = "{}-{}-cp27-cp27mu-manylinux1_x86_64.whl".format(framework, framework_version)
-    os.system("curl {} > {}/../docker/{}/final/{}/{}".format(BASE_PATH, optbin_link, framework_version, pyV, optbin_filename))
-    # 3.) Build base image
-    print("Building base image...")
-    image_name = "{}-base:{}-{}-{}".format(framework, framework_version, processor,  pyV)
-    base_docker_path = "{}/../docker/{}/base/Dockerfile.{}".format(BASE_PATH, framework_version, processor)
-    os.system("sudo nvidia-docker build -t {} -f {} .".format(image_name, base_docker_path))
-    # 4.) Build final image
-    print("Building final image...")
-    os.chdir("{}/..".format(BASE_PATH))
-    os.system("python setup.py sdist")
-    os.system("cp dist/sagemaker_tensorflow_container-*.tar.gz docker/{}/final/{}".format(framework_version, pyV))
-    os.chdir("docker/{}/final/{}".format(framework_version, pyV))
-    os.system \
-        ("sudo nvidia-docker build -t preprod-{}:{}-{}-{} --build-arg py_version={} --build-arg framework_installable={}  -f Dockerfile.{} .".format
-            (framework, framework_version, processor, pyV, pyV[-1], optbin_filename, processor))
-    # 5.) Return to build_scripts directory
-    os.chdir("{}".format(BASE_PATH))
+    print('Getting optimized binary...')
+    optbin_filename = 'tensorflow-{}-cp27-cp27mu-manylinux1_x86_64.whl'.format(framework_version)
+    with open('{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, optbin_filename), 'wb') as optbin_file:
+        subprocess.call(['curl', optbin_link], stdout=optbin_file)
 
-if __name__ == "__main__":
+    # 3.) Build base image
+    print('Building base image...')
+    image_name = 'tensorflow-base:{}-{}-{}'.format(framework_version, processor,  py_v)
+    base_docker_path = '{}/../docker/{}/base/Dockerfile.{}'.format(PATH_TO_SCRIPT, framework_version, processor)
+    subprocess.call(['sudo', DOCKER, 'build', '-t', image_name, '-f', base_docker_path, '.'])
+
+    # 4.) Build final image
+    print('Building final image...')
+    subprocess.call(['python', 'setup.py', 'sdist'], cwd='{}/..'.format(PATH_TO_SCRIPT))
+    output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0] # use glob to use regex
+    subprocess.call(['cp', output_file, '{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v)])
+    subprocess.call(['sudo', DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v), \
+                    '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename), \
+                    '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
+
+if __name__ == '__main__':
     # Parse command line options
-    parser = argparse.ArgumentParser(description="Build Sagemaker Tensorflow Docker Images")
-    parser.add_argument("optimized_binary_link", help="link to place with optimized binary")
-    parser.add_argument("processor_type", help="gpu if you would like to use GPUs or cpu")
-    parser.add_argument("framework_version", help="Tensorflow framework version (i.e. 1.8.0)")
-    parser.add_argument("python_version", help="Python version to be used (i.e. 2.7.0)")
+    parser = argparse.ArgumentParser(description='Build Sagemaker TensorFlow Docker Images')
+    parser.add_argument('optimized_binary_link', help='link to place with optimized binary')
+    parser.add_argument('processor_type', choices=['cpu', 'gpu'], help='gpu if you would like to use GPUs or cpu')
+    parser.add_argument('framework_version', help='TensorFlow framework version (i.e. 1.8.0)')
+    parser.add_argument('python_version', help='Python version to be used (i.e. 2.7.0)')
+    parser.add_argument('--nvidia-docker', action='store_true', help="Enables nvidia-docker usage over docker usage")
     args = parser.parse_args()
-    # Sets BASE_PATH so that command can be run from anywhere
-    BASE_PATH = "/".join(sys.argv[0].split('/')[:-1])
-    BASE_PATH = "." if BASE_PATH == "" else BASE_PATH
+
+    # Set value for docker
+    DOCKER = 'nvidia-docker' if args.nvidia_docker else DOCKER
+
+    # Sets PATH_TO_SCRIPT so that command can be run from anywhere
+    PATH_TO_SCRIPT = '/'.join(sys.argv[0].split('/')[:-1])
+    PATH_TO_SCRIPT = '.' if PATH_TO_SCRIPT == '' else PATH_TO_SCRIPT
+
     # Build image
     create_docker_image(args.optimized_binary_link, args.processor_type, args.framework_version, args.python_version)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -5,6 +5,7 @@
 """
 import argparse
 import glob
+import shutil
 import subprocess
 import sys
 
@@ -34,14 +35,14 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     print('Building base image...')
     image_name = 'tensorflow-base:{}-{}-{}'.format(framework_version, processor,  py_v)
     base_docker_path = '{}/../docker/{}/base/Dockerfile.{}'.format(PATH_TO_SCRIPT, framework_version, processor)
-    subprocess.call(['sudo', DOCKER, 'build', '-t', image_name, '-f', base_docker_path, '.'])
+    subprocess.call([DOCKER, 'build', '-t', image_name, '-f', base_docker_path, '.'])
 
     # 4.) Build final image
     print('Building final image...')
     subprocess.call(['python', 'setup.py', 'sdist'], cwd='{}/..'.format(PATH_TO_SCRIPT))
     output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0] # use glob to use regex
-    subprocess.call(['cp', output_file, '{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v)])
-    subprocess.call(['sudo', DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v), \
+    shutil.copyfile(output_file, '{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
+    subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v), \
                     '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename), \
                     '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
 
@@ -59,8 +60,7 @@ if __name__ == '__main__':
     DOCKER = 'nvidia-docker' if args.nvidia_docker else DOCKER
 
     # Sets PATH_TO_SCRIPT so that command can be run from anywhere
-    PATH_TO_SCRIPT = '/'.join(sys.argv[0].split('/')[:-1])
-    PATH_TO_SCRIPT = '.' if PATH_TO_SCRIPT == '' else PATH_TO_SCRIPT
+    PATH_TO_SCRIPT = os.path.join('.', '/'.join(sys.argv[0].split('/')[:-1]))
 
     # Build image
     create_docker_image(args.optimized_binary_link, args.processor_type, args.framework_version, args.python_version)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -22,26 +22,26 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
         framework_version (str): tensorflow version i.e 1.6.0
         python_version (str): (i.e. 3.6.5 or 2.7.4)
     """
-    # 1.) Initialize commonly used variables
+    # Initialize commonly used variables
     py_v = 'py{}'.format(python_version.split('.')[0]) # i.e. py2
 
-    # 2.) Get optimized binary - and put in final docker image repo
+    # Get optimized binary - and put in final docker image repo
     print('Getting optimized binary...')
     optbin_filename = 'tensorflow-{}-cp27-cp27mu-manylinux1_x86_64.whl'.format(framework_version)
     with open('{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, optbin_filename), 'wb') as optbin_file:
         subprocess.call(['curl', optbin_link], stdout=optbin_file)
 
-    # 3.) Build base image
+    # Build base image
     print('Building base image...')
     image_name = 'tensorflow-base:{}-{}-{}'.format(framework_version, processor,  py_v)
     base_docker_path = '{}/../docker/{}/base/Dockerfile.{}'.format(PATH_TO_SCRIPT, framework_version, processor)
     subprocess.call([DOCKER, 'build', '-t', image_name, '-f', base_docker_path, '.'])
 
-    # 4.) Build final image
+    # Build final image
     print('Building final image...')
     subprocess.call(['python', 'setup.py', 'sdist'], cwd='{}/..'.format(PATH_TO_SCRIPT))
-    output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0] # use glob to use regex
-    shutil.copyfile(output_file, '{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
+    shutil.copyfile('{}/../dist/sagemaker_tensorflow_container-*.tar.gz', '{}/../docker/{}/final/{}' \
+                    .format(PATH_TO_SCRIPT, PATH_TO_SCRIPT, framework_version, py_v))
     subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v), \
                     '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename), \
                     '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -1,7 +1,7 @@
 """
 Script to run docker image creation
 Run the command:
-    python docker_image_creator.py docker_file_github_link optimized_binary_link gpu|cpu tensorflow_version python_version
+    python docker_image_creator.py optimized_binary_link gpu|cpu tensorflow_version python_version
 """
 import argparse
 import os
@@ -39,6 +39,8 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     os.system \
         ("sudo nvidia-docker build -t preprod-{}:{}-{}-{} --build-arg py_version={} --build-arg framework_installable={}  -f Dockerfile.{} .".format
             (framework, framework_version, processor, pyV, pyV[-1], optbin_filename, processor))
+    # 5.) Return to build_scripts directory
+    os.chdir("../../../../build_scripts")
 
 if __name__ == "__main__":
     # Parse command line options

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -1,0 +1,60 @@
+"""
+Implements the parent function for docker image creation during single instance configuration
+"""
+import argparse
+import os
+
+def tensorflow_create_docker(dockerfile_github_link, optbin_link, gpu, framework_version, python_version):
+    """
+    Function builds a docker image with the TF optimized binary
+
+    :param dockerfile_github_link: link to docker file repo
+    :param optbin_link: link to where the optimized binary is
+    :param gpu: True for gpu false for cpu
+    :param framework_version: deep learning framework version i.e 1.6.0
+    :param python_version: version of python to build container with i.e. 3.6.5 or 2.7.4
+    :return: final built imageid
+    """
+    # 0.) Initialize some commonly used variables
+    processor = "gpu" if gpu else "cpu"
+    dockerfile_repo_name = dockerfile_github_link.split('/')[-1].split('.')[0]
+    pyV = "py{}".format(python_version.split('.')[0]) # i.e. py2
+    framework = "tensorflow"
+    # 1.) Clone dockerfile repo from Github
+    os.system("git clone {}".format(dockerfile_github_link))
+    # 2.) Get optimized binary - probably need to better parametrize the name
+    optbin_filename = "{}-{}-cp27-cp27mu-manylinux1_x86_64.whl".format(framework, framework_version) # just a tmp file name
+    os.system("curl {} > {}".format(optbin_link, optbin_filename))
+    # 3.) Build base image
+    image_name = "{}-base:{}-{}-{}".format(framework, framework_version, processor,  pyV)
+    base_docker_path = "docker/{}/base/Dockerfile.{}".format(framework_version, processor)
+    os.system("sudo nvidia-docker build -t {} -f {}/{} .".format(image_name, dockerfile_repo_name, base_docker_path))
+    # 4.) Build final image
+    os.chdir("{}".format(dockerfile_repo_name))
+    os.system("python setup.py sdist")
+    os.system("cp dist/sagemaker_tensorflow_container-1.0.0.tar.gz docker/{}/final/{}".format(framework_version, pyV))
+    os.system("cp ../{}  docker/{}/final/{}".format(optbin_filename, framework_version, pyV))
+    os.chdir("docker/{}/final/{}".format(framework_version, pyV))
+    os.system \
+        ("sudo nvidia-docker build -t preprod-{}:{}-{}-{} --build-arg py_version={} --build-arg framework_installable={}  -f Dockerfile.{} .".format
+            (framework, framework_version, processor, pyV, pyV[-1], optbin_filename, processor))
+    # 5.) Clean everything up
+    print("Cleaning up...")
+    os.chdir("../../../../..")
+    os.system("sudo rm -r {} {}".format(optbin_filename, dockerfile_repo_name))
+    # 6.) Return image id
+    image_id = os.popen("sudo nvidia-docker images preprod-{}:{}-{}-{} -q".format(framework, framework_version, processor, python_version)).read()
+    return image_id[:-1] # removes endline
+
+
+if __name__ == "__main__":
+    # Parse command line options
+    parser = argparse.ArgumentParser()
+    parser.add_argument("docker_file_github_link", help="link to github containing docker files")
+    parser.add_argument("optimized_binary_link", "link to place with optimized binary")
+    parser.add_argument("processor_type", help="'gpu' if you would like to use GPUs or 'cpu'")
+    parser.add_argument("framework_version", help="Tensorflow framework version (i.e. 1.8.0)")
+    parser.add_argument("python_version", help="Python version to be used (i.e. 2.7.0)")
+    args = parser.parse_args()
+    # Build image
+    tensorflow_create_docker(args.dockerfile_github_link, args.optimized_binary, args.gpu, args.framework_version, args.python_version)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -1,9 +1,8 @@
-""" Script to create Sagemaker TensorFlow Docker image
-    Run the command:
+""" Script to create Sagemaker TensorFlow Docker images
+
+    Usage:
         python docker_image_creator.py optimized_binary_link gpu|cpu tensorflow_version python_version
-
 """
-
 import argparse
 import glob
 import subprocess
@@ -17,11 +16,10 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     """ Function builds a docker image with the TF optimized binary
 
     Args:
-        param1 (str): optbin_link - link to where the optimized binary is
-        param2 (str): processor - gpu or cpu
-        param3 (str): framework_version - tensorflow version i.e 1.6.0
-        param4 (str): python_version (i.e. 3.6.5 or 2.7.4)
-
+        optbin_link (str): link to where the optimized binary is
+        processor (str): gpu or cpu
+        framework_version (str): tensorflow version i.e 1.6.0
+        python_version (str): (i.e. 3.6.5 or 2.7.4)
     """
     # 1.) Initialize commonly used variables
     py_v = 'py{}'.format(python_version.split('.')[0]) # i.e. py2

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -1,7 +1,7 @@
 """ Script to create Sagemaker TensorFlow Docker images
 
     Usage:
-        python docker_image_creator.py optimized_binary_link gpu|cpu tensorflow_version python_version
+        python docker_image_creator.py binary_path gpu|cpu tensorflow_version python_version
 """
 import argparse
 import glob
@@ -10,33 +10,34 @@ import shutil
 import subprocess
 import sys
 
-def create_docker_image(processor, framework_version, python_version, optbin_path):
+def create_docker_image(binary_path, processor, framework_version, python_version, final_image_repository, final_image_tags):
     """ Function builds a docker image
 
     Args:
         processor (str): gpu or cpu
         framework_version (str): tensorflow version i.e 1.6.0
         python_version (str): (i.e. 3.6.5 or 2.7.4)
-        optbin_path (str): link to where the optimized binary is.
+        binary_path (str): path to where the binary is.
+        final_image_repository (str): name of final repo. If None, 'preprod-tensorflow' will be used
+        final_image_tags (list(str)): list of tag names for final image. If set to empty, default tag will be used
     """
     # Initialize commonly used variables
     py_v = 'py{}'.format(python_version.split('.')[0]) # i.e. py2
+    base_docker_path = '{}/../docker/{}/base/Dockerfile.{}'.format(PATH_TO_SCRIPT, framework_version, processor)
+    final_docker_path = '{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v)
 
-    # If necessary, get optimized binary and put in final docker image repo
-    if optbin_path:
-        print('Getting optimized binary...')
-        # Name of file will be the end of the path
-        optbin_filename = optbin_path.split('/')[-1]
-        if os.path.isfile(optbin_path):
-            shutil.copyfile(optbin_filename, '{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, output_filename))
-        else:
-            with open('{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, optbin_filename), 'wb') as optbin_file:
-                subprocess.call(['curl', optbin_path], stdout=optbin_file)
+    # Get binary file
+    print('Getting binary...')
+    binary_filename = binary_path.split('/')[-1]
+    if os.path.isfile(binary_path):
+        shutil.copyfile(binary_path, '{}/{}'.format(final_docker_path, binary_filename))
+    else:
+        with open('{}/{}'.format(final_docker_path, binary_filename), 'wb') as binary_file:
+            subprocess.call(['curl', binary_path], stdout=binary_file)
 
     # Build base image
     print('Building base image...')
     image_name = 'tensorflow-base:{}-{}-{}'.format(framework_version, processor,  py_v)
-    base_docker_path = '{}/../docker/{}/base/Dockerfile.{}'.format(PATH_TO_SCRIPT, framework_version, processor)
     subprocess.call([DOCKER, 'build', '-t', image_name, '-f', base_docker_path, '.'])
 
     #  Build final image
@@ -44,25 +45,30 @@ def create_docker_image(processor, framework_version, python_version, optbin_pat
     subprocess.call(['python', 'setup.py', 'sdist'], cwd='{}/..'.format(PATH_TO_SCRIPT))
     output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0]
     output_filename = output_file.split('/')[-1]
-    shutil.copyfile(output_file, '{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, output_filename))
-    if optbin_path:
-        print("Building with binary")
-        subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v),
-                        '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename),
-                        '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
-    else:
-        subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v),
-                        '--build-arg', 'py_version={}'.format(py_v[-1]), '-f', 'Dockerfile.{}'.format(processor), '.'],
-                        cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
+    shutil.copyfile(output_file, '{}/{}'.format(final_docker_path, output_filename))
+
+    final_image_repository = final_image_repository if final_image_repository else 'preprod-tensorflow'
+    final_image_tags = final_image_tags if final_image_tags else ['{}-{}-{}'.format(framework_version, processor, py_v)]
+    command_list = [DOCKER, 'build']
+    for tag in final_image_tags:
+        command_list.append('-t')
+        command_list.append('{}:{}'.format(final_image_repository, tag))
+
+    command_list.extend(['--build-arg', 'py_version={}'.format(py_v[-1]),
+                    '--build-arg', 'framework_installable={}'.format(binary_filename),
+                    '-f', 'Dockerfile.{}'.format(processor), '.'])
+    subprocess.call(command_list, cwd=final_docker_path)
 
 if __name__ == '__main__':
     # Parse command line options
     parser = argparse.ArgumentParser(description='Build Sagemaker TensorFlow Docker Images')
+    parser.add_argument('binary_path', help='path to the binary')
     parser.add_argument('processor_type', choices=['cpu', 'gpu'], help='gpu if you would like to use GPUs or cpu')
     parser.add_argument('framework_version', help='TensorFlow framework version (i.e. 1.8.0)')
     parser.add_argument('python_version', help='Python version to be used (i.e. 2.7.0)')
-    parser.add_argument('--optimized-binary-path', default=None, help='path to optimized binary')
-    parser.add_argument('--nvidia-docker', action='store_true', help="Enables nvidia-docker usage over docker usage")
+    parser.add_argument('--nvidia-docker', action='store_true', help='Enables nvidia-docker usage over docker usage')
+    parser.add_argument('--final-image-repository', default=None, help='Name of final repo the image is stored in')
+    parser.add_argument('--final-image-tags', default=[], nargs='+', help='List of tag names for final image')
     args = parser.parse_args()
 
     # Set value for docker
@@ -72,4 +78,5 @@ if __name__ == '__main__':
     PATH_TO_SCRIPT = os.path.dirname(os.path.abspath(sys.argv[0]))
 
     # Build image
-    create_docker_image(args.processor_type, args.framework_version, args.python_version, args.optimized_binary_path)
+    create_docker_image(args.binary_path, args.processor_type, args.framework_version, args.python_version,
+                        args.final_image_repository, args.final_image_tags)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -4,7 +4,7 @@ Implements the parent function for docker image creation during single instance 
 import argparse
 import os
 
-def tensorflow_create_docker(dockerfile_github_link, optbin_link, gpu, framework_version, python_version):
+def create_docker_image(dockerfile_github_link, optbin_link, processor_type, framework_version, python_version):
     """
     Function builds a docker image with the TF optimized binary
 
@@ -16,7 +16,7 @@ def tensorflow_create_docker(dockerfile_github_link, optbin_link, gpu, framework
     :return: final built imageid
     """
     # 0.) Initialize some commonly used variables
-    processor = "gpu" if gpu else "cpu"
+    processor = processor_type
     dockerfile_repo_name = dockerfile_github_link.split('/')[-1].split('.')[0]
     pyV = "py{}".format(python_version.split('.')[0]) # i.e. py2
     framework = "tensorflow"
@@ -52,10 +52,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("dockerfile_github_link", help="link to github containing docker files")
     parser.add_argument("optimized_binary_link", help="link to place with optimized binary")
-    parser.add_argument("processor_type", help="'gpu' if you would like to use GPUs or 'cpu'")
+    parser.add_argument("processor_type", help="gpu if you would like to use GPUs or cpu")
     parser.add_argument("framework_version", help="Tensorflow framework version (i.e. 1.8.0)")
     parser.add_argument("python_version", help="Python version to be used (i.e. 2.7.0)")
     args = parser.parse_args()
-    gpu = True if args.processor_type == "gpu" else False
     # Build image
-    tensorflow_create_docker(args.dockerfile_github_link, args.optimized_binary, gpu, args.framework_version, args.python_version)
+    create_docker_image(args.dockerfile_github_link, args.optimized_binary_link, args.processor_type, args.framework_version, args.python_version)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -15,9 +15,6 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     """
     Function builds a docker image with the TF optimized binary
 
-    Assumptions:
-        1. Script needs to be run inside of the build_scripts files
-
     :param optbin_link: link to where the optimized binary is
     :param processor: gpu or cpu
     :param framework_version: tensorflow version i.e 1.6.0

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -13,7 +13,7 @@ def create_docker_image(dockerfile_github_link, optbin_link, processor, framewor
     :param dockerfile_github_link: link to docker file repo
     :param optbin_link: link to where the optimized binary is
     :param processor: gpu or cpu
-    :param framework_version: deep learning framework version i.e 1.6.0
+    :param framework_version: tensorflow version i.e 1.6.0
     :param python_version: version of python to build container with i.e. 3.6.5 or 2.7.4
     :return: final built imageid
     """

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # Parse command line options
     parser = argparse.ArgumentParser()
     parser.add_argument("docker_file_github_link", help="link to github containing docker files")
-    parser.add_argument("optimized_binary_link", "link to place with optimized binary")
+    parser.add_argument("optimized_binary_link", help="link to place with optimized binary")
     parser.add_argument("processor_type", help="'gpu' if you would like to use GPUs or 'cpu'")
     parser.add_argument("framework_version", help="Tensorflow framework version (i.e. 1.8.0)")
     parser.add_argument("python_version", help="Python version to be used (i.e. 2.7.0)")

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -5,6 +5,11 @@ Run the command:
 """
 import argparse
 import os
+import sys
+
+## GLOBALS
+# Allows user to run script anywhere
+BASE_PATH = ""
 
 def create_docker_image(optbin_link, processor, framework_version, python_version):
     """
@@ -24,15 +29,15 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     # 2.) Get optimized binary - and put in final docker image repo
     print("Getting optimized binary...")
     optbin_filename = "{}-{}-cp27-cp27mu-manylinux1_x86_64.whl".format(framework, framework_version)
-    os.system("curl {} > ../docker/{}/final/{}/{}".format(optbin_link, framework_version, pyV, optbin_filename))
+    os.system("curl {} > {}/../docker/{}/final/{}/{}".format(BASE_PATH, optbin_link, framework_version, pyV, optbin_filename)) # ADDED BASE_PATH
     # 3.) Build base image
     print("Building base image...")
     image_name = "{}-base:{}-{}-{}".format(framework, framework_version, processor,  pyV)
-    base_docker_path = "../docker/{}/base/Dockerfile.{}".format(framework_version, processor)
+    base_docker_path = "{}/../docker/{}/base/Dockerfile.{}".format(framework_version, processor)  # ADDED BASE_PATH
     os.system("sudo nvidia-docker build -t {} -f {} .".format(image_name, base_docker_path))
     # 4.) Build final image
     print("Building final image...")
-    os.chdir("..")
+    os.chdir("{}/..".format(BASE_PATH)) # ADDED BASE_PATH
     os.system("python setup.py sdist")
     os.system("cp dist/sagemaker_tensorflow_container-*.tar.gz docker/{}/final/{}".format(framework_version, pyV))
     os.chdir("docker/{}/final/{}".format(framework_version, pyV))
@@ -40,15 +45,18 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
         ("sudo nvidia-docker build -t preprod-{}:{}-{}-{} --build-arg py_version={} --build-arg framework_installable={}  -f Dockerfile.{} .".format
             (framework, framework_version, processor, pyV, pyV[-1], optbin_filename, processor))
     # 5.) Return to build_scripts directory
-    os.chdir("../../../../build_scripts")
+    os.chdir("{}".format(BASE_PATH)) # ADDED BASE_PATH
 
 if __name__ == "__main__":
     # Parse command line options
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Build Sagemaker Tensorflow Docker Images")
     parser.add_argument("optimized_binary_link", help="link to place with optimized binary")
     parser.add_argument("processor_type", help="gpu if you would like to use GPUs or cpu")
     parser.add_argument("framework_version", help="Tensorflow framework version (i.e. 1.8.0)")
     parser.add_argument("python_version", help="Python version to be used (i.e. 2.7.0)")
     args = parser.parse_args()
+    # Sets BASE_PATH so that command can be run from anywhere
+    BASE_PATH = "/".join(sys.argv[0].split('/')[:-1])
+    BASE_PATH = "." if BASE_PATH == "" else BASE_PATH
     # Build image
     create_docker_image(args.optimized_binary_link, args.processor_type, args.framework_version, args.python_version)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -50,11 +50,12 @@ def tensorflow_create_docker(dockerfile_github_link, optbin_link, gpu, framework
 if __name__ == "__main__":
     # Parse command line options
     parser = argparse.ArgumentParser()
-    parser.add_argument("docker_file_github_link", help="link to github containing docker files")
+    parser.add_argument("dockerfile_github_link", help="link to github containing docker files")
     parser.add_argument("optimized_binary_link", help="link to place with optimized binary")
     parser.add_argument("processor_type", help="'gpu' if you would like to use GPUs or 'cpu'")
     parser.add_argument("framework_version", help="Tensorflow framework version (i.e. 1.8.0)")
     parser.add_argument("python_version", help="Python version to be used (i.e. 2.7.0)")
     args = parser.parse_args()
+    gpu = True if args.processor_type == "gpu" else False
     # Build image
-    tensorflow_create_docker(args.dockerfile_github_link, args.optimized_binary, args.gpu, args.framework_version, args.python_version)
+    tensorflow_create_docker(args.dockerfile_github_link, args.optimized_binary, gpu, args.framework_version, args.python_version)

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -42,7 +42,8 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     print('Building final image...')
     subprocess.call(['python', 'setup.py', 'sdist'], cwd='{}/..'.format(PATH_TO_SCRIPT))
     output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0] # use glob to use regex
-    shutil.copyfile(output_file, '{}/../docker/{}/final/{}/'.format(PATH_TO_SCRIPT, framework_version, py_v))
+    output_filename = output_file.split('/')[-1]
+    shutil.copyfile(output_file, '{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, output_filename))
     subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v), \
                     '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename), \
                     '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -4,6 +4,7 @@
         python docker_image_creator.py optimized_binary_link gpu|cpu tensorflow_version python_version
 """
 import argparse
+import glob
 import os
 import shutil
 import subprocess
@@ -37,11 +38,11 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     base_docker_path = '{}/../docker/{}/base/Dockerfile.{}'.format(PATH_TO_SCRIPT, framework_version, processor)
     subprocess.call([DOCKER, 'build', '-t', image_name, '-f', base_docker_path, '.'])
 
-    # Build final image
+    #  Build final image
     print('Building final image...')
     subprocess.call(['python', 'setup.py', 'sdist'], cwd='{}/..'.format(PATH_TO_SCRIPT))
-    shutil.copyfile('{}/../dist/sagemaker_tensorflow_container-*.tar.gz', '{}/../docker/{}/final/{}' \
-                    .format(PATH_TO_SCRIPT, PATH_TO_SCRIPT, framework_version, py_v))
+    output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0] # use glob to use regex
+    shutil.copyfile(output_file, '{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
     subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v), \
                     '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename), \
                     '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -30,7 +30,7 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     # 3.) Build base image
     print("Building base image...")
     image_name = "{}-base:{}-{}-{}".format(framework, framework_version, processor,  pyV)
-    base_docker_path = "{}/../docker/{}/base/Dockerfile.{}".format(framework_version, processor)
+    base_docker_path = "{}/../docker/{}/base/Dockerfile.{}".format(BASE_PATH, framework_version, processor)
     os.system("sudo nvidia-docker build -t {} -f {} .".format(image_name, base_docker_path))
     # 4.) Build final image
     print("Building final image...")

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -26,15 +26,15 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     # 2.) Get optimized binary - and put in final docker image repo
     print("Getting optimized binary...")
     optbin_filename = "{}-{}-cp27-cp27mu-manylinux1_x86_64.whl".format(framework, framework_version)
-    os.system("curl {} > {}/../docker/{}/final/{}/{}".format(BASE_PATH, optbin_link, framework_version, pyV, optbin_filename)) # ADDED BASE_PATH
+    os.system("curl {} > {}/../docker/{}/final/{}/{}".format(BASE_PATH, optbin_link, framework_version, pyV, optbin_filename))
     # 3.) Build base image
     print("Building base image...")
     image_name = "{}-base:{}-{}-{}".format(framework, framework_version, processor,  pyV)
-    base_docker_path = "{}/../docker/{}/base/Dockerfile.{}".format(framework_version, processor)  # ADDED BASE_PATH
+    base_docker_path = "{}/../docker/{}/base/Dockerfile.{}".format(framework_version, processor)
     os.system("sudo nvidia-docker build -t {} -f {} .".format(image_name, base_docker_path))
     # 4.) Build final image
     print("Building final image...")
-    os.chdir("{}/..".format(BASE_PATH)) # ADDED BASE_PATH
+    os.chdir("{}/..".format(BASE_PATH))
     os.system("python setup.py sdist")
     os.system("cp dist/sagemaker_tensorflow_container-*.tar.gz docker/{}/final/{}".format(framework_version, pyV))
     os.chdir("docker/{}/final/{}".format(framework_version, pyV))
@@ -42,7 +42,7 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
         ("sudo nvidia-docker build -t preprod-{}:{}-{}-{} --build-arg py_version={} --build-arg framework_installable={}  -f Dockerfile.{} .".format
             (framework, framework_version, processor, pyV, pyV[-1], optbin_filename, processor))
     # 5.) Return to build_scripts directory
-    os.chdir("{}".format(BASE_PATH)) # ADDED BASE_PATH
+    os.chdir("{}".format(BASE_PATH))
 
 if __name__ == "__main__":
     # Parse command line options

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -42,7 +42,7 @@ def create_docker_image(optbin_link, processor, framework_version, python_versio
     print('Building final image...')
     subprocess.call(['python', 'setup.py', 'sdist'], cwd='{}/..'.format(PATH_TO_SCRIPT))
     output_file = glob.glob('{}/../dist/sagemaker_tensorflow_container-*.tar.gz'.format(PATH_TO_SCRIPT))[0] # use glob to use regex
-    shutil.copyfile(output_file, '{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))
+    shutil.copyfile(output_file, '{}/../docker/{}/final/{}/'.format(PATH_TO_SCRIPT, framework_version, py_v))
     subprocess.call([DOCKER, 'build', '-t', 'preprod-tensorflow:{}-{}-{}'.format(framework_version, processor, py_v), \
                     '--build-arg', 'py_version={}'.format(py_v[-1]), '--build-arg', 'framework_installable={}'.format(optbin_filename), \
                     '-f', 'Dockerfile.{}'.format(processor), '.'], cwd='{}/../docker/{}/final/{}'.format(PATH_TO_SCRIPT, framework_version, py_v))

--- a/build_scripts/docker_image_creator.py
+++ b/build_scripts/docker_image_creator.py
@@ -31,7 +31,7 @@ def create_docker_image(processor, framework_version, python_version, optbin_pat
             shutil.copyfile(optbin_filename, '{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, output_filename))
         else:
             with open('{}/../docker/{}/final/{}/{}'.format(PATH_TO_SCRIPT, framework_version, py_v, optbin_filename), 'wb') as optbin_file:
-                subprocess.call(['curl', optbin_link], stdout=optbin_file)
+                subprocess.call(['curl', optbin_path], stdout=optbin_file)
 
     # Build base image
     print('Building base image...')


### PR DESCRIPTION
I added a python script to build images. It takes 5 arguments: link to dockerfile github address, link to the tensorflow optimized binary address, gpu or cpu, framework version and python version. It then builds the final image.

To run this script, it requires that you have nvidia-docker installed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
