### PR TITLE
Only save one model at end of training

### DIFF
--- a/src/tf_container/trainer.py
+++ b/src/tf_container/trainer.py
@@ -127,8 +127,7 @@ class Trainer(object):
 
         if self.saves_training():
             serving_input_receiver_fn = lambda: self.customer_script.serving_input_fn(self.customer_params)
-            exporter = tf.estimator.LatestExporter('Servo',
-                                                   serving_input_receiver_fn=serving_input_receiver_fn)
+            exporter = tf.estimator.FinalExporter('Servo', serving_input_receiver_fn=serving_input_receiver_fn)
         else:
             logger.warn('serving_input_fn not specified, model NOT saved, use checkpoints to reconstruct')
             exporter = None

--- a/test/integ/test_estimator_classification.py
+++ b/test/integ/test_estimator_classification.py
@@ -39,6 +39,8 @@ def test_estimator_classification(docker_image, sagemaker_session, opt_ml, proce
     train(docker_image, opt_ml, processor)
 
     assert file_exists(opt_ml, 'model/export/Servo'), 'model was not exported'
+    num_models = len([name for name in os.listdir(os.path.join(opt_ml, 'model/export/Servo'))])
+    assert num_models == 1, 'too many models saved: {}'.format(num_models)
     assert file_exists(opt_ml, 'model/checkpoint'), 'checkpoint was not created'
     assert file_exists(opt_ml, 'output/success'), 'Success file was not created'
     assert not file_exists(opt_ml, 'output/failure'), 'Failure happened'

--- a/test/unit/test_trainer.py
+++ b/test/unit/test_trainer.py
@@ -279,7 +279,7 @@ def test_build_eval_spec_with_serving(modules, trainer):
 
     spec = trainer._build_eval_spec()
 
-    exporter_mock = modules.estimator.LatestExporter
+    exporter_mock = modules.estimator.FinalExporter
     exporter_mock.assert_called_with('Servo', serving_input_receiver_fn=ANY)
     _, kwargs = exporter_mock.call_args
     serving_input_fn = kwargs['serving_input_receiver_fn']
@@ -293,7 +293,7 @@ def test_build_eval_spec_with_serving(modules, trainer):
     eval_input_fn = args[0]
     returned_dict, returned_labels = eval_input_fn()
     assert (tensor_dict, labels) == (returned_dict, returned_labels)
-    # Assert the created LatestExporter is passed correctly to the EvalSpec
+    # Assert the created FinalExporter is passed correctly to the EvalSpec
     assert exporter_mock.return_value == kwargs['exporters']
     # Assert the created EvalSpec is returned from _build_eval_spec
     assert evalspec_mock.return_value == spec


### PR DESCRIPTION
Change the Trainer class to use FinalExporter[1] instead of LatestExporter[2] so we
only save one copy of the model at end of training. Sometimes saving and
removing models causes S3 errors, this change should reduce such errors.

[1] https://www.tensorflow.org/api_docs/python/tf/estimator/FinalExporter
[2] https://www.tensorflow.org/api_docs/python/tf/estimator/LatestExporter

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
