### PR TITLE
Update readme with instructions for 1.9.0 and above

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,8 @@ Base Images
 ~~~~~~~~~~~
 
 The "base" Dockerfile encompass the installation of the framework and all of the dependencies
-needed.
+needed. It is needed before building container for TensorFlow 1.8.0 and before. Container of TensorFlow 1.9.0
+do not need to build this base image.
 
 Tagging scheme is based on <tensorflow_version>-<processor>-<python_version>. (e.g. 1.4
 .1-cpu-py2)
@@ -98,7 +99,7 @@ Final Images
 
 The "final" Dockerfiles encompass the installation of the SageMaker specific support code.
 
-All “final” Dockerfiles use `base images for building <https://github
+For images of TensorFlow 1.8.0 and before, all “final” Dockerfiles use `base images for building <https://github
 .com/aws/sagemaker-tensorflow-containers/blob/master/docker/1.4.1/final/py2/Dockerfile.cpu#L2>`__.
 
 These “base” images are specified with the naming convention of
@@ -107,7 +108,9 @@ tensorflow-base:<tensorflow_version>-<processor>-<python_version>.
 Before building “final” images:
 
 Build your “base” image. Make sure it is named and tagged in accordance with your “final”
-Dockerfile.
+Dockerfile. Skip this step if you want to build image of Tensorflow Version 1.9.0 and above.
+
+Then prepare the SageMaker TensorFlow Container python package in the image folder like below:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,8 @@ Base Images
 ~~~~~~~~~~~
 
 The "base" Dockerfile encompass the installation of the framework and all of the dependencies
-needed. It is needed before building container for TensorFlow 1.8.0 and before. Container of TensorFlow 1.9.0
-do not need to build this base image.
+needed. It is needed before building image for TensorFlow 1.8.0 and before.
+Building a base image is not required for images for TensorFlow 1.9.0 and onwards.
 
 Tagging scheme is based on <tensorflow_version>-<processor>-<python_version>. (e.g. 1.4
 .1-cpu-py2)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-tensorflow-container/issues/73

*Description of changes:*
Update README for building 1.9.0 and above. It doesn't need a base image anymore. And the longtime plan is to have one docker file just for all versions and just leave an example for old style build (base from framework source + final) for reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
