### PR TITLE
Default GRPC timeout for EI & Allow timeout to be configurable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     install_requires=['sagemaker-container-support'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',
-                 'sagemaker', 'tensorflow']
+                 'sagemaker', 'tensorflow', 'tensorflow-serving-api']
     },
 )

--- a/src/tf_container/proxy_client.py
+++ b/src/tf_container/proxy_client.py
@@ -27,7 +27,7 @@ from tensorflow_serving.apis import prediction_service_pb2
 from tf_container.run import logger as _logger
 
 INFERENCE_ACCELERATOR_PRESENT_ENV = 'SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT'
-TF_SERVING_REQUEST_TIMEOUT_ENV = 'SAGEMAKER_TFS_GRPC_REQUEST_TIMEOUT'
+TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV = 'SAGEMAKER_TFS_GRPC_REQUEST_TIMEOUT'
 
 REGRESSION = 'tensorflow/serving/regression'
 CLASSIFY = 'tensorflow/serving/classify'
@@ -41,8 +41,8 @@ class GRPCProxyClient(object):
                  model_name=GENERIC_MODEL_NAME,
                  input_tensor_name=PREDICT_INPUTS,
                  signature_name=DEFAULT_SERVING_SIGNATURE_DEF_KEY):
-        if os.environ.get(TF_SERVING_REQUEST_TIMEOUT_ENV):
-            request_timeout = int(TF_SERVING_REQUEST_TIMEOUT_ENV)
+        if os.environ.get(TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV):
+            request_timeout = int(TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV)
         elif os.environ.get(INFERENCE_ACCELERATOR_PRESENT_ENV) == 'true':
             request_timeout = 30.0
 

--- a/src/tf_container/proxy_client.py
+++ b/src/tf_container/proxy_client.py
@@ -29,6 +29,8 @@ from tf_container.run import logger as _logger
 INFERENCE_ACCELERATOR_PRESENT_ENV = 'SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT'
 TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV = 'SAGEMAKER_TFS_GRPC_REQUEST_TIMEOUT'
 
+DEFAULT_GRPC_REQUEST_TIMEOUT_FOR_INFERENCE_ACCELERATOR = 30.0
+
 REGRESSION = 'tensorflow/serving/regression'
 CLASSIFY = 'tensorflow/serving/classify'
 INFERENCE = 'tensorflow/serving/inference'
@@ -42,9 +44,9 @@ class GRPCProxyClient(object):
                  input_tensor_name=PREDICT_INPUTS,
                  signature_name=DEFAULT_SERVING_SIGNATURE_DEF_KEY):
         if os.environ.get(TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV):
-            request_timeout = float(os.env.get(TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV))
+            request_timeout = float(os.environ.get(TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV))
         elif os.environ.get(INFERENCE_ACCELERATOR_PRESENT_ENV) == 'true':
-            request_timeout = 30.0
+            request_timeout = DEFAULT_GRPC_REQUEST_TIMEOUT_FOR_INFERENCE_ACCELERATOR
 
         self.tf_serving_port = tf_serving_port
         self.host = host

--- a/src/tf_container/proxy_client.py
+++ b/src/tf_container/proxy_client.py
@@ -10,6 +10,7 @@
 #  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 #  express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import os
 
 import numpy as np
 from google.protobuf import json_format
@@ -25,6 +26,8 @@ from tensorflow_serving.apis import prediction_service_pb2
 
 from tf_container.run import logger as _logger
 
+INFERENCE_ACCELERATOR_PRESENT_ENV = 'SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT'
+
 REGRESSION = 'tensorflow/serving/regression'
 CLASSIFY = 'tensorflow/serving/classify'
 INFERENCE = 'tensorflow/serving/inference'
@@ -37,6 +40,9 @@ class GRPCProxyClient(object):
                  model_name=GENERIC_MODEL_NAME,
                  input_tensor_name=PREDICT_INPUTS,
                  signature_name=DEFAULT_SERVING_SIGNATURE_DEF_KEY):
+        if os.environ.get(INFERENCE_ACCELERATOR_PRESENT_ENV) == 'true':
+            request_timeout = 30.0
+
         self.tf_serving_port = tf_serving_port
         self.host = host
         self.request_timeout = request_timeout

--- a/src/tf_container/proxy_client.py
+++ b/src/tf_container/proxy_client.py
@@ -42,7 +42,7 @@ class GRPCProxyClient(object):
                  input_tensor_name=PREDICT_INPUTS,
                  signature_name=DEFAULT_SERVING_SIGNATURE_DEF_KEY):
         if os.environ.get(TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV):
-            request_timeout = int(TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV)
+            request_timeout = float(os.env.get(TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV))
         elif os.environ.get(INFERENCE_ACCELERATOR_PRESENT_ENV) == 'true':
             request_timeout = 30.0
 

--- a/src/tf_container/proxy_client.py
+++ b/src/tf_container/proxy_client.py
@@ -27,6 +27,7 @@ from tensorflow_serving.apis import prediction_service_pb2
 from tf_container.run import logger as _logger
 
 INFERENCE_ACCELERATOR_PRESENT_ENV = 'SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT'
+TF_SERVING_REQUEST_TIMEOUT_ENV = 'SAGEMAKER_TFS_GRPC_REQUEST_TIMEOUT'
 
 REGRESSION = 'tensorflow/serving/regression'
 CLASSIFY = 'tensorflow/serving/classify'
@@ -40,7 +41,9 @@ class GRPCProxyClient(object):
                  model_name=GENERIC_MODEL_NAME,
                  input_tensor_name=PREDICT_INPUTS,
                  signature_name=DEFAULT_SERVING_SIGNATURE_DEF_KEY):
-        if os.environ.get(INFERENCE_ACCELERATOR_PRESENT_ENV) == 'true':
+        if os.environ.get(TF_SERVING_REQUEST_TIMEOUT_ENV):
+            request_timeout = int(TF_SERVING_REQUEST_TIMEOUT_ENV)
+        elif os.environ.get(INFERENCE_ACCELERATOR_PRESENT_ENV) == 'true':
             request_timeout = 30.0
 
         self.tf_serving_port = tf_serving_port

--- a/test/unit/test_experiment_trainer.py
+++ b/test/unit/test_experiment_trainer.py
@@ -1,14 +1,14 @@
 #  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License").
 #  You may not use this file except in compliance with the License.
 #  A copy of the License is located at
-#  
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#  
-#  or in the "license" file accompanying this file. This file is distributed 
-#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-#  express or implied. See the License for the specific language governing 
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
 import pytest

--- a/test/unit/test_proxy_client.py
+++ b/test/unit/test_proxy_client.py
@@ -84,6 +84,13 @@ class TensorProto(object):
 
 @patch.dict(os.environ, {'SAGEMAKER_TFS_GRPC_REQUEST_TIMEOUT': '300.0',
                          'SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT': 'true'}, clear=True)
+def test_user_supplied_custom_tfs_timeout_with_ei():
+    client = GRPCProxyClient(DEFAULT_PORT)
+
+    assert client.request_timeout == 300.0
+
+
+@patch.dict(os.environ, {'SAGEMAKER_TFS_GRPC_REQUEST_TIMEOUT': '300.0'}, clear=True)
 def test_user_supplied_custom_tfs_timeout():
     client = GRPCProxyClient(DEFAULT_PORT)
 

--- a/test/unit/test_proxy_client.py
+++ b/test/unit/test_proxy_client.py
@@ -1,22 +1,26 @@
 #  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License").
 #  You may not use this file except in compliance with the License.
 #  A copy of the License is located at
-#  
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#  
-#  or in the "license" file accompanying this file. This file is distributed 
-#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-#  express or implied. See the License for the specific language governing 
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
 import json
+import os
 
 import pytest
-from mock import MagicMock, patch, ANY
+from google import protobuf
+from mock import MagicMock, patch, ANY, Mock
+from tensorflow_serving.apis import prediction_service_pb2, get_model_metadata_pb2, \
+    classification_pb2, predict_pb2, inference_pb2, regression_pb2
 
-from test.unit.utils import mock_import_modules
+from tf_container.proxy_client import GRPCProxyClient
 
 REGRESSION = 'tensorflow/serving/regression'
 INFERENCE = 'tensorflow/serving/inference'
@@ -25,47 +29,13 @@ PREDICT = 'tensorflow/serving/predict'
 
 
 @pytest.fixture()
-def set_up():
-    modules_to_mock = [
-        'numpy',
-        'grpc.beta',
-        'tensorflow.python.framework',
-        'tensorflow.core.framework',
-        'tensorflow_serving.apis',
-        'tensorflow.python.saved_model.signature_constants',
-        'google.protobuf.json_format',
-        'tensorflow.contrib.learn.python.learn.utils',
-        'tensorflow.contrib.training.HParams',
-        'tensorflow.python.estimator',
-        'tensorflow.core.example',
-        'grpc.framework.interfaces.face.face'
-    ]
-    mock, modules = mock_import_modules(modules_to_mock)
-
-    patcher = patch.dict('sys.modules', modules)
-    patcher.start()
-    from tf_container.proxy_client import GRPCProxyClient
+def proxy_client():
     proxy_client = GRPCProxyClient(9000, input_tensor_name='inputs',
                                    signature_name='serving_default')
     proxy_client.input_type_map['sometype'] = 'somedtype'
     proxy_client.prediction_service_stub = MagicMock()
 
-    yield mock, proxy_client
-    patcher.stop()
-
-
-@pytest.fixture()
-def set_up_requests(set_up):
-    mock, proxy_client = set_up
-    mock.tensor_pb2.TensorProto = TensorProto
-    mock.predict_pb2.PredictRequest = PredictRequest
-    mock.classification_pb2.ClassificationRequest = ClassificationRequest
-    mock.example_pb2.Example = Example
-    mock.feature_pb2.Features = Features
-    mock.feature_pb2.Feature = Feature
-    mock.feature_pb2.Int64List = FeatureList
-    mock.feature_pb2.BytesList = FeatureList
-    mock.feature_pb2.FloatList = FeatureList
+    yield proxy_client
 
 
 class PredictRequest(object):
@@ -110,59 +80,69 @@ class TensorProto(object):
         self.data = data
 
 
-def test_parse_request_predict(set_up):
-    mock, proxy_client = set_up
+@patch.dict(os.environ, {'SAGEMAKER_TFS_GRPC_REQUEST_TIMEOUT': '300',
+                         'SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT': 'true'}, clear=True)
+def test_user_supplied_custom_tfs_timeout():
+    client = GRPCProxyClient(9000)
+
+    assert client.request_timeout == 300
+
+
+@patch.dict(os.environ, {'SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT': 'true'}, clear=True)
+def test_default_tfs_ei_timeout():
+    client = GRPCProxyClient(9000)
+
+    assert client.request_timeout == 30
+
+
+@patch('tensorflow_serving.apis.predict_pb2.PredictRequest')
+def test_parse_request_predict(mock_request, proxy_client):
     proxy_client.prediction_type = PREDICT
 
-    patch_metadata_request_with(mock, PREDICT)
+    patch_metadata_request_with(PREDICT)
     proxy_client.parse_request('serialized_data')
 
-    mock_request = mock.predict_pb2.PredictRequest
     mock_request.assert_called_once()
     mock_request().ParseFromString.assert_called_once_with('serialized_data')
 
 
-def test_parse_request_classification(set_up):
-    mock, proxy_client = set_up
+@patch('tensorflow_serving.apis.classification_pb2.ClassificationRequest')
+def test_parse_request_classification(mock_request, proxy_client):
     proxy_client.prediction_type = CLASSIFY
 
-    patch_metadata_request_with(mock, CLASSIFY)
+    patch_metadata_request_with(CLASSIFY)
     proxy_client.parse_request('serialized_data')
 
-    mock_request = mock.classification_pb2.ClassificationRequest
     mock_request.assert_called_once()
     mock_request().ParseFromString.assert_called_once_with('serialized_data')
 
 
-def test_parse_request_inference(set_up):
-    mock, proxy_client = set_up
+@patch('tensorflow_serving.apis.inference_pb2.MultiInferenceRequest')
+def test_parse_request_inference(mock_request, proxy_client):
     proxy_client.prediction_type = INFERENCE
 
-    patch_metadata_request_with(mock, INFERENCE)
+    patch_metadata_request_with(INFERENCE)
     proxy_client.parse_request('serialized_data')
 
-    mock_request = mock.inference_pb2.MultiInferenceRequest
     mock_request.assert_called_once()
     mock_request().ParseFromString.assert_called_once_with('serialized_data')
 
 
-def test_parse_request_regression(set_up):
-    mock, proxy_client = set_up
+@patch('tensorflow_serving.apis.regression_pb2.RegressionRequest')
+def test_parse_request_regression(mock_request, proxy_client):
     proxy_client.prediction_type = REGRESSION
 
-    patch_metadata_request_with(mock, REGRESSION)
+    patch_metadata_request_with(REGRESSION)
     proxy_client.parse_request('serialized_data')
 
-    mock_request = mock.regression_pb2.RegressionRequest
     mock_request.assert_called_once()
     mock_request().ParseFromString.assert_called_once_with('serialized_data')
 
 
-def test_request_predict(set_up):
-    mock, proxy_client = set_up
+def test_request_predict(proxy_client):
     proxy_client.prediction_type = PREDICT
 
-    patch_metadata_request_with(mock, PREDICT)
+    patch_metadata_request_with(PREDICT)
 
     predict_fn_mock = MagicMock()
     proxy_client.request_fn_map[PREDICT] = predict_fn_mock
@@ -172,11 +152,10 @@ def test_request_predict(set_up):
     predict_fn_mock.assert_called_once_with('my_data')
 
 
-def test_request_classification(set_up):
-    mock, proxy_client = set_up
+def test_request_classification(proxy_client):
     proxy_client.prediction_type = CLASSIFY
 
-    patch_metadata_request_with(mock, CLASSIFY)
+    patch_metadata_request_with(CLASSIFY)
 
     mock = MagicMock()
     proxy_client.request_fn_map[CLASSIFY] = mock
@@ -186,26 +165,27 @@ def test_request_classification(set_up):
     mock.assert_called_once_with('my_data')
 
 
-def test_request_not_implemented(set_up):
-    mock, proxy_client = set_up
-
+def test_request_not_implemented(proxy_client):
     with pytest.raises(NotImplementedError):
-        patch_metadata_request_with(mock, INFERENCE)
+        patch_metadata_request_with(INFERENCE)
         proxy_client.prediction_type = INFERENCE
 
         proxy_client.request('my_data')
 
     with pytest.raises(NotImplementedError):
-        patch_metadata_request_with(mock, REGRESSION)
+        patch_metadata_request_with(REGRESSION)
         proxy_client.prediction_type = REGRESSION
 
         proxy_client.request('my_data')
 
 
-def test_predict_with_tensor_proto(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+@patch('tensorflow_serving.apis.predict_pb2.PredictRequest', new=PredictRequest)
+@patch('tf_container.proxy_client.make_tensor_proto')
+def test_predict_with_tensor_proto(make_tensor_proto, proxy_client):
     tensor_proto = TensorProto('/42-sagemaker')
+
+    make_tensor_proto.return_value = tensor_proto
+
     prediction = proxy_client.predict(tensor_proto)
 
     predict_fn = proxy_client.prediction_service_stub.Predict
@@ -220,10 +200,11 @@ def test_predict_with_tensor_proto(set_up, set_up_requests):
     assert prediction == predict_fn.return_value
 
 
-def test_predict_with_dict(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+@patch('tensorflow_serving.apis.predict_pb2.PredictRequest', new=PredictRequest)
+@patch('tf_container.proxy_client.make_tensor_proto')
+def test_predict_with_dict(make_tensor_proto, proxy_client):
     tensor_proto = TensorProto('/42-sagemaker')
+    make_tensor_proto.return_value = tensor_proto
     prediction = proxy_client.predict({'inputs': tensor_proto})
 
     predict_fn = proxy_client.prediction_service_stub.Predict
@@ -238,9 +219,9 @@ def test_predict_with_dict(set_up, set_up_requests):
     assert prediction == predict_fn.return_value
 
 
-def test_predict_with_predict_request(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+@patch('tensorflow_serving.apis.predict_pb2.PredictRequest', new=PredictRequest)
+@patch('tf_container.proxy_client.make_tensor_proto')
+def test_predict_with_predict_request(make_tensor_proto, proxy_client):
     request = PredictRequest()
     prediction = proxy_client.predict(request)
 
@@ -252,9 +233,7 @@ def test_predict_with_predict_request(set_up, set_up_requests):
 
 
 @patch('tf_container.proxy_client.make_tensor_proto', side_effect=Exception('tensor proto failed!'))
-def test_predict_with_invalid_payload(make_tensor_proto, set_up, set_up_requests):
-    _, proxy_client = set_up
-
+def test_predict_with_invalid_payload(make_tensor_proto, proxy_client):
     data = complex('1+2j')
 
     with pytest.raises(ValueError) as error:
@@ -264,9 +243,7 @@ def test_predict_with_invalid_payload(make_tensor_proto, set_up, set_up_requests
 
 
 @patch('tf_container.proxy_client.make_tensor_proto', return_value='MyTensorProto')
-def test_predict_create_input_map_with_dict_of_lists(make_tensor_proto, set_up, set_up_requests):
-    _, proxy_client = set_up
-
+def test_predict_create_input_map_with_dict_of_lists(make_tensor_proto, proxy_client):
     data = {'mytensor': [1, 2, 3]}
 
     result = proxy_client._create_input_map(data)
@@ -274,9 +251,8 @@ def test_predict_create_input_map_with_dict_of_lists(make_tensor_proto, set_up, 
     make_tensor_proto.assert_called_once()
 
 
-def test_classification_with_classification_request(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+@patch('tensorflow_serving.apis.classification_pb2.ClassificationRequest', new=ClassificationRequest)
+def test_classification_with_classification_request(proxy_client):
     request = ClassificationRequest()
 
     prediction = proxy_client.classification(request)
@@ -287,9 +263,7 @@ def test_classification_with_classification_request(set_up, set_up_requests):
     assert prediction == classification_fn.return_value
 
 
-def test_classification_with_int_list(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+def test_classification_with_int_list(proxy_client):
     proxy_client.classification([1, 2, 3, 0])
 
     classification_request = _get_classification_request(proxy_client)
@@ -300,9 +274,7 @@ def test_classification_with_int_list(set_up, set_up_requests):
     assert feature['inputs'].bytes_list.value == []
 
 
-def test_classification_with_bytes_list(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+def test_classification_with_bytes_list(proxy_client):
     bytes = ['fnenfionk4235g', 'faf']
     proxy_client.classification(bytes)
 
@@ -314,10 +286,8 @@ def test_classification_with_bytes_list(set_up, set_up_requests):
     assert feature['inputs'].bytes_list.value == bytes
 
 
-def test_classification_with_float_list(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
-    data = [3.4, 0.0, 0.0]
+def test_classification_with_float_list(proxy_client):
+    data = [3.4000000953674316, 0.0, 0.0]
     proxy_client.classification(data)
 
     classification_request = _get_classification_request(proxy_client)
@@ -328,9 +298,7 @@ def test_classification_with_float_list(set_up, set_up_requests):
     assert feature['inputs'].bytes_list.value == []
 
 
-def test_classification_with_int(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+def test_classification_with_int(proxy_client):
     proxy_client.classification(1)
 
     classification_request = _get_classification_request(proxy_client)
@@ -341,9 +309,7 @@ def test_classification_with_int(set_up, set_up_requests):
     assert feature['inputs'].bytes_list.value == []
 
 
-def test_classification_with_bytes(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+def test_classification_with_bytes(proxy_client):
     bytes = 'fnenfionk4235g'
     proxy_client.classification(bytes)
 
@@ -355,10 +321,8 @@ def test_classification_with_bytes(set_up, set_up_requests):
     assert feature['inputs'].bytes_list.value == [bytes]
 
 
-def test_classification_with_float(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
-    data = 3.4
+def test_classification_with_float(proxy_client):
+    data = 3.4000000953674316
     proxy_client.classification(data)
     proxy_client.prediction_service_stub.Classify.assert_called_once()
 
@@ -370,9 +334,7 @@ def test_classification_with_float(set_up, set_up_requests):
     assert feature['inputs'].bytes_list.value == []
 
 
-def test_classification_with_invalid_payload(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+def test_classification_with_invalid_payload(proxy_client):
     data = complex('1+2j')
 
     with pytest.raises(ValueError) as error:
@@ -381,26 +343,25 @@ def test_classification_with_invalid_payload(set_up, set_up_requests):
     assert 'Unsupported request data format' in str(error)
 
 
-def test_classification_protobuf(set_up, set_up_requests):
-    mock, proxy_client = set_up
-
+def test_classification_protobuf(proxy_client):
     request = MagicMock()
     proxy_client.classification(request)
     proxy_client.prediction_service_stub.Classify.assert_called_once()
 
 
-def test_cache_prediction_metadata(set_up):
-    mock, proxy_client = set_up
-
+@patch('tensorflow_serving.apis.get_model_metadata_pb2.SignatureDefMap')
+@patch('tensorflow_serving.apis.get_model_metadata_pb2.GetModelMetadataRequest')
+@patch('tensorflow_serving.apis.prediction_service_pb2.beta_create_PredictionService_stub')
+@patch('grpc.beta.implementations.insecure_channel')
+def test_cache_prediction_metadata(channel, stub, request, signature_def_map, proxy_client):
     proxy_client.cache_prediction_metadata()
 
-    channel = mock.implementations.insecure_channel
     channel.assert_called_once_with('localhost', 9000)
 
-    stub = mock.prediction_service_pb2.beta_create_PredictionService_stub
+    stub = prediction_service_pb2.beta_create_PredictionService_stub
     stub.assert_called_once_with(channel())
 
-    request = mock.get_model_metadata_pb2.GetModelMetadataRequest
+    request = get_model_metadata_pb2.GetModelMetadataRequest
     request.assert_called_once()
 
     stub().GetModelMetadata.assert_called_once_with(request(), 10.0)
@@ -408,8 +369,8 @@ def test_cache_prediction_metadata(set_up):
     assert proxy_client.prediction_service_stub == stub.return_value
 
 
-def patch_metadata_request_with(mock, method_name):
-    mock.protobuf.json_format.MessageToJson.return_value = json.dumps({
+def patch_metadata_request_with(method_name):
+    protobuf.json_format.MessageToJson.return_value = json.dumps({
         'metadata': {
             'signature_def': {
                 'signatureDef': {

--- a/test/unit/test_proxy_client.py
+++ b/test/unit/test_proxy_client.py
@@ -16,9 +16,8 @@ import os
 
 import pytest
 from google import protobuf
-from mock import MagicMock, patch, ANY, Mock
-from tensorflow_serving.apis import prediction_service_pb2, get_model_metadata_pb2, \
-    classification_pb2, predict_pb2, inference_pb2, regression_pb2
+from mock import MagicMock, patch, ANY
+from tensorflow_serving.apis import prediction_service_pb2, get_model_metadata_pb2
 
 from tf_container.proxy_client import GRPCProxyClient
 
@@ -30,6 +29,7 @@ PREDICT = 'tensorflow/serving/predict'
 DEFAULT_PORT = 9000
 INPUT_TENSOR_NAME = 'inputs'
 
+
 @pytest.fixture()
 def proxy_client():
     proxy_client = GRPCProxyClient(DEFAULT_PORT, input_tensor_name=INPUT_TENSOR_NAME,
@@ -37,7 +37,7 @@ def proxy_client():
     proxy_client.input_type_map['sometype'] = 'somedtype'
     proxy_client.prediction_service_stub = MagicMock()
 
-    yield proxy_client
+    return proxy_client
 
 
 class PredictRequest(object):

--- a/test/unit/test_trainer.py
+++ b/test/unit/test_trainer.py
@@ -186,7 +186,7 @@ def test_user_model_fn(modules, trainer):
     estimator = trainer._build_estimator(fake_run_config)
 
     estimator_mock = modules.estimator.Estimator
-    # Verify that _model_fn passed to Estimator correctly passes args through to user script model_fn 
+    # Verify that _model_fn passed to Estimator correctly passes args through to user script model_fn
     estimator_mock.assert_called_with(model_fn=ANY, params=expected_hps, config=fake_run_config)
     _, kwargs, = estimator_mock.call_args
     kwargs['model_fn'](1, 2, 3, 4)


### PR DESCRIPTION
Added default timeout for EI.

Added env var to allow customers to configure their own timeout.

Also removed module mocks from test_proxy_client and test_serve.

In favor of https://github.com/aws/sagemaker-tensorflow-container/pull/101

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
