### PR TITLE
Deprecate get_marker. Use get_closest_marker instead

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -96,8 +96,8 @@ def instance_type(request, processor):
 @pytest.fixture(autouse=True)
 def skip_by_device_type(request, processor):
     is_gpu = (processor == 'gpu')
-    if (request.node.get_marker('skip_gpu') and is_gpu) or \
-            (request.node.get_marker('skip_cpu') and not is_gpu):
+    if (request.node.get_closest_marker('skip_gpu') and is_gpu) or \
+            (request.node.get_closest_marker('skip_cpu') and not is_gpu):
         pytest.skip('Skipping because running on \'{}\' instance'.format(processor))
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
