### PR TITLE
Read framework version from Python SDK for integ test default

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,6 +18,7 @@ import os
 import boto3
 import pytest
 from sagemaker import LocalSession, Session
+from sagemaker.tensorflow import TensorFlow
 
 logger = logging.getLogger(__name__)
 logging.getLogger('boto').setLevel(logging.INFO)
@@ -33,7 +34,7 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='preprod-tensorflow')
     parser.addoption('--tag', default=None)
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default='1.12.0')
+    parser.addoption('--framework-version', default=TensorFlow.LATEST_VERSION)
     parser.addoption('--processor', default='cpu', choices=['gpu', 'cpu'])
     parser.addoption('--py-version', default='3', choices=['2', '3'])
     parser.addoption('--account-id', default='142577830533')


### PR DESCRIPTION
following [aws/sagemaker-mxnet-container#67](https://github.com/aws/sagemaker-mxnet-container/pull/67) and [aws/sagemaker-tensorflow-container#166](https://github.com/aws/sagemaker-tensorflow-container/pull/166) and [aws/sagemaker-chainer-container#70](https://github.com/aws/sagemaker-chainer-container/pull/70) and https://github.com/aws/sagemaker-pytorch-container/pull/76

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
