### PR TITLE
Pass HostingEnvironment in serve.transformer

### DIFF
--- a/src/tf_container/serve.py
+++ b/src/tf_container/serve.py
@@ -95,8 +95,8 @@ def _recursive_copy(src, dst):
                 os.mkdir(os.path.join(target_path, dir))
 
 
-def transformer(user_module):
-    env = cs.HostingEnvironment()
+def transformer(user_module, env=None):
+    env = cs.HostingEnvironment() if env is None else env
 
     port = int(cs.Server.next_safe_port(env.port_range)) if env.port_range else DEFAULT_TF_SERVING_PORT
 

--- a/test/unit/test_serve.py
+++ b/test/unit/test_serve.py
@@ -77,6 +77,27 @@ def mod():
     yield m
 
 
+@patch('container_support.HostingEnvironment')
+@patch('container_support.Server.next_safe_port')
+@patch('tf_container.proxy_client.GRPCProxyClient')
+@patch('tf_container.serve._wait_model_to_load')
+def test_transformer_with_env(wait_model_to_load, grpc, next_safe_port, env):
+    test_port = '8888'
+    env.port_range = test_port
+    serve.transformer(user_module=Mock(), env=env)
+    next_safe_port.assert_called_with(test_port)
+    env.assert_not_called()
+
+
+@patch('container_support.HostingEnvironment')
+@patch('container_support.Server.next_safe_port')
+@patch('tf_container.proxy_client.GRPCProxyClient')
+@patch('tf_container.serve._wait_model_to_load')
+def test_transformer_without_env(wait_model_to_load, grpc, next_safe_port, env):
+    serve.transformer(user_module=Mock())
+    env.assert_called_once()
+
+
 @patch('google.protobuf.json_format.MessageToJson', side_effect=json.dumps)
 def test_transformer_provides_default_transformer_fn(message):
     grpc_proxy_client = Mock()


### PR DESCRIPTION
Loading the environment variables is unnecessary. This is negatively affecting
the inference performance

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
