### PR TITLE
restore python-dev package in image

### DIFF
--- a/docker/1.11.0/final/py2/Dockerfile.cpu
+++ b/docker/1.11.0/final/py2/Dockerfile.cpu
@@ -9,7 +9,7 @@ ARG framework_support_installable=sagemaker_tensorflow_container-1.0.0.tar.gz
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    python \
+    python-dev \
     curl \
     nginx \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/1.11.0/final/py2/Dockerfile.gpu
+++ b/docker/1.11.0/final/py2/Dockerfile.gpu
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcudnn7=${CUDNN_VERSION} \
         libnccl2=${NCCL_VERSION} \
         libgomp1 \
-        python \
+        python-dev \
         curl \
         nginx \
         && \

--- a/docker/1.12.0/final/py2/Dockerfile.cpu
+++ b/docker/1.12.0/final/py2/Dockerfile.cpu
@@ -9,7 +9,7 @@ ARG framework_support_installable=sagemaker_tensorflow_container-1.0.0.tar.gz
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    python \
+    python-dev \
     curl \
     nginx \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/1.12.0/final/py2/Dockerfile.ei
+++ b/docker/1.12.0/final/py2/Dockerfile.ei
@@ -9,7 +9,7 @@ ARG tensorflow_model_server
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    python \
+    python-dev \
     curl \
     nginx \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/1.12.0/final/py2/Dockerfile.gpu
+++ b/docker/1.12.0/final/py2/Dockerfile.gpu
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcudnn7=${CUDNN_VERSION} \
         libnccl2=${NCCL_VERSION} \
         libgomp1 \
-        python \
+        python-dev \
         curl \
         nginx \
         && \

--- a/docker/1.4.1/base/Dockerfile.gpu
+++ b/docker/1.4.1/base/Dockerfile.gpu
@@ -77,7 +77,7 @@ RUN git apply --verbose /patches/*.patch
 
 
 # Configure the build for our CUDA configuration.
-ENV CI_BUILD_PYTHON=python \
+ENV CI_BUILD_PYTHON=python-dev \
     LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH \
     TF_NEED_CUDA=1 \
     TF_CUDA_VERSION=8.0 \


### PR DESCRIPTION
*Issue #, if available:* #172 

*Description of changes:*

Several earlier versions of the tensorflow container have had python-dev installed, but this was changed to 'python' in recent builds.

This restores python-dev, which allows python package requirements that require compilation to function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
