### PR TITLE
Fix typo in serving method name

### DIFF
--- a/src/tf_container/proxy_client.py
+++ b/src/tf_container/proxy_client.py
@@ -31,7 +31,7 @@ TF_SERVING_GRPC_REQUEST_TIMEOUT_ENV = 'SAGEMAKER_TFS_GRPC_REQUEST_TIMEOUT'
 
 DEFAULT_GRPC_REQUEST_TIMEOUT_FOR_INFERENCE_ACCELERATOR = 30.0
 
-REGRESSION = 'tensorflow/serving/regression'
+REGRESSION = 'tensorflow/serving/regress'
 CLASSIFY = 'tensorflow/serving/classify'
 INFERENCE = 'tensorflow/serving/inference'
 PREDICT = 'tensorflow/serving/predict'

--- a/test/unit/test_proxy_client.py
+++ b/test/unit/test_proxy_client.py
@@ -21,7 +21,7 @@ from tensorflow_serving.apis import prediction_service_pb2, get_model_metadata_p
 
 from tf_container.proxy_client import GRPCProxyClient
 
-REGRESSION = 'tensorflow/serving/regression'
+REGRESSION = 'tensorflow/serving/regress'
 INFERENCE = 'tensorflow/serving/inference'
 CLASSIFY = 'tensorflow/serving/classify'
 PREDICT = 'tensorflow/serving/predict'


### PR DESCRIPTION
The correct method name is  "tensorflow/serving/regress" - https://www.tensorflow.org/tfx/serving/signature_defs

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
