### PR TITLE
Add mpi4py to pip installs

### DIFF
--- a/docker/1.12.0/Dockerfile.cpu
+++ b/docker/1.12.0/Dockerfile.cpu
@@ -71,11 +71,12 @@ RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
 ARG framework_installable
 ARG framework_support_installable=sagemaker_tensorflow_container-2.0.0.tar.gz
 
-COPY $framework_installable tensorflow-1.12.0-py2.py3-none-any.whl  
+COPY $framework_installable tensorflow-1.12.0-py2.py3-none-any.whl
 COPY $framework_support_installable .
 
 RUN pip install --no-cache-dir -U \
         keras==2.2.4 \
+        mpi4py==3.0.1 \
         "sagemaker-tensorflow>=1.12,<1.13" && \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten

--- a/docker/1.12.0/Dockerfile.gpu
+++ b/docker/1.12.0/Dockerfile.gpu
@@ -112,6 +112,7 @@ COPY $framework_support_installable .
 
 RUN pip install --no-cache-dir -U \
     keras==2.2.4 \
+    mpi4py==3.0.1 \
     $framework_support_installable \
     "sagemaker-tensorflow>=1.12,<1.13" \
     # Let's install TensorFlow separately in the end to avoid


### PR DESCRIPTION
corresponds to https://github.com/aws/sagemaker-containers/pull/191

*Description of changes:*
MPI may fail to detect process failure, which can cause a process to hang. mpi4py forces all processes to abort if an uncaught exception occurs. See https://docs.chainer.org/en/stable/chainermn/tutorial/tips_faqs.html#mpi-process-hangs-after-an-unhandled-python-exception (though the link is related to Chainer, it says that the problem is not specific to ChainerNM).

I tested locally (so CPU only) with the related SageMaker Containers change to ensure that Horovod should still work, including checking the assert statement mentioned in https://github.com/horovod/horovod#mpi4py.

edit: not sure why the CodeBuild run is still showing as a failure; I restarted it (failure was due to a tuning job name collision) and it passed: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/sagemaker-tensorflow-container-integ-p36-gpu/build/sagemaker-tensorflow-container-integ-p36-gpu%3A194011a1-f1c0-4135-8530-58f734484084/log

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
