### PR TITLE
fix: add setup file back to remote-test command

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -4,6 +4,8 @@ env:
   variables:
     FRAMEWORK_VERSION: '1.13.1'
     GPU_INSTANCE_TYPE: 'ml.p2.xlarge'
+    SETUP_FILE: 'setup_cmds.sh'
+    SETUP_CMDS: '#!/bin/bash\npip install --upgrade pip\npip install -U -e .\npip install -U -e .[test]'
 
 phases:
   pre_build:
@@ -45,11 +47,12 @@ phases:
       - instance_type=${GPU_INSTANCE_TYPE#"$prefix"}
       - create-key-pair
       - launch-ec2-instance --instance-type $instance_type --ami-name dlami-ubuntu
+      - printf "$SETUP_CMDS" > $SETUP_FILE
 
       - py2_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --docker-base-name $base_name --py-version 2 --framework-version $FRAMEWORK_VERSION --processor gpu"
-      - remote-test --github-repo sagemaker-tensorflow-container --branch script-mode --test-cmd "$py2_cmd"
+      - remote-test --github-repo sagemaker-tensorflow-container --setup-file $SETUP_FILE --branch script-mode --test-cmd "$py2_cmd"
       - py3_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local --docker-base-name $base_name --framework-version $FRAMEWORK_VERSION --processor gpu"
-      - remote-test --github-repo sagemaker-tensorflow-container --branch script-mode --test-cmd "$py3_cmd"
+      - remote-test --github-repo sagemaker-tensorflow-container --setup-file $SETUP_FILE --branch script-mode --test-cmd "$py3_cmd"
 
       - |
         echo '[{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The latest release build failed because of the gpu test can not find tox. Adding the setup file back so we will install all the test dependencies in case we need them to kick off the tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
