### PR TITLE
fix: use unique name for integration job hyperparameter tuning job

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-application_import_names = sagemaker_tensorflow_container, test
+application_import_names = sagemaker_tensorflow_container, test, utils
 import-order-style = google

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 **/.ipynb_checkpoints
 **/.python-version
 .tox
+*~

--- a/test/integration/sagemaker/test_horovod.py
+++ b/test/integration/sagemaker/test_horovod.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -16,6 +16,8 @@ import os
 
 import sagemaker
 from sagemaker.tensorflow import TensorFlow
+
+from utils import unique_name_from_base
 
 RESOURCE_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
 
@@ -41,7 +43,7 @@ def test_distributed_training_horovod(sagemaker_session,
                          'sagemaker_mpi_num_of_processes_per_host': 1},
         sagemaker_session=sagemaker_session)
 
-    estimator.fit()
+    estimator.fit(job_name=unique_name_from_base('test-tf-horovod'))
 
     model_data_source = sagemaker.local.data.get_data_source_instance(
         estimator.model_data, sagemaker_session)

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -30,7 +30,8 @@ def test_mnist(sagemaker_session, ecr_image, instance_type):
                            train_instance_type=instance_type,
                            train_instance_count=1,
                            sagemaker_session=sagemaker_session,
-                           image_name=ecr_image)
+                           image_name=ecr_image,
+                           script_mode=True)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data'),
         key_prefix='scriptmode/mnist')
@@ -46,7 +47,8 @@ def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type):
                            train_instance_count=2,
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
-                           image_name=ecr_image)
+                           image_name=ecr_image,
+                           script_mode=True)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data'),
         key_prefix='scriptmode/mnist')
@@ -63,7 +65,8 @@ def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type):
                            train_instance_count=2,
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
-                           image_name=ecr_image)
+                           image_name=ecr_image,
+                           script_mode=True)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data-distributed'),
         key_prefix='scriptmode/mnist-distributed')
@@ -94,7 +97,8 @@ def test_s3_plugin(sagemaker_session, ecr_image, instance_type, region):
                            train_instance_count=1,
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
-                           image_name=ecr_image)
+                           image_name=ecr_image,
+                           script_mode=True)
     estimator.fit('s3://sagemaker-sample-data-{}/tensorflow/mnist'.format(region),
                   job_name=unique_name_from_base('test-tf-sm-s3-mnist'))
     _assert_s3_file_exists(region, estimator.model_data)

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -19,9 +19,10 @@ from sagemaker.tensorflow import TensorFlow
 from six.moves.urllib.parse import urlparse
 
 from sagemaker_tensorflow_container.training import SAGEMAKER_PARAMETER_SERVER_ENABLED
+from utils import unique_name_from_base
 
 
-def test_mnist(sagemaker_session, ecr_image, instance_type, framework_version):
+def test_mnist(sagemaker_session, ecr_image, instance_type):
     resource_path = os.path.join(os.path.dirname(__file__), '../..', 'resources')
     script = os.path.join(resource_path, 'mnist', 'mnist.py')
     estimator = TensorFlow(entry_point=script,
@@ -29,18 +30,15 @@ def test_mnist(sagemaker_session, ecr_image, instance_type, framework_version):
                            train_instance_type=instance_type,
                            train_instance_count=1,
                            sagemaker_session=sagemaker_session,
-                           image_name=ecr_image,
-                           framework_version=framework_version,
-                           py_version='py3',
-                           base_job_name='test-sagemaker-mnist')
+                           image_name=ecr_image)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data'),
         key_prefix='scriptmode/mnist')
-    estimator.fit(inputs)
+    estimator.fit(inputs, job_name=unique_name_from_base('test-sagemaker-mnist'))
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
-def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, framework_version):
+def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type):
     resource_path = os.path.join(os.path.dirname(__file__), '../..', 'resources')
     script = os.path.join(resource_path, 'mnist', 'mnist.py')
     estimator = TensorFlow(entry_point=script,
@@ -48,18 +46,15 @@ def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, fr
                            train_instance_count=2,
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
-                           image_name=ecr_image,
-                           framework_version=framework_version,
-                           py_version='py3',
-                           base_job_name='test-tf-sm-distributed-mnist')
+                           image_name=ecr_image)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data'),
         key_prefix='scriptmode/mnist')
-    estimator.fit(inputs)
+    estimator.fit(inputs, job_name=unique_name_from_base('test-tf-sm-distributed-mnist'))
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
-def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type, framework_version):
+def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type):
     resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
     script = os.path.join(resource_path, 'mnist', 'mnist_estimator.py')
     estimator = TensorFlow(entry_point=script,
@@ -68,19 +63,16 @@ def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type, frame
                            train_instance_count=2,
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
-                           image_name=ecr_image,
-                           framework_version=framework_version,
-                           py_version='py3',
-                           base_job_name='test-tf-sm-distributed-mnist')
+                           image_name=ecr_image)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data-distributed'),
         key_prefix='scriptmode/mnist-distributed')
-    estimator.fit(inputs)
+    estimator.fit(inputs, job_name=unique_name_from_base('test-tf-sm-distributed-mnist'))
     _assert_checkpoint_exists(sagemaker_session.boto_region_name, estimator.model_dir, 0)
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
-def test_s3_plugin(sagemaker_session, ecr_image, instance_type, region, framework_version):
+def test_s3_plugin(sagemaker_session, ecr_image, instance_type, region):
     resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
     script = os.path.join(resource_path, 'mnist', 'mnist_estimator.py')
     estimator = TensorFlow(entry_point=script,
@@ -102,11 +94,9 @@ def test_s3_plugin(sagemaker_session, ecr_image, instance_type, region, framewor
                            train_instance_count=1,
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
-                           image_name=ecr_image,
-                           framework_version=framework_version,
-                           py_version='py3',
-                           base_job_name='test-tf-sm-s3-mnist')
-    estimator.fit('s3://sagemaker-sample-data-{}/tensorflow/mnist'.format(region))
+                           image_name=ecr_image)
+    estimator.fit('s3://sagemaker-sample-data-{}/tensorflow/mnist'.format(region),
+                  job_name=unique_name_from_base('test-tf-sm-s3-mnist'))
     _assert_s3_file_exists(region, estimator.model_data)
     _assert_checkpoint_exists(region, estimator.model_dir, 200)
 

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -22,7 +22,7 @@ from sagemaker_tensorflow_container.training import SAGEMAKER_PARAMETER_SERVER_E
 from utils import unique_name_from_base
 
 
-def test_mnist(sagemaker_session, ecr_image, instance_type):
+def test_mnist(sagemaker_session, ecr_image, instance_type, framework_version):
     resource_path = os.path.join(os.path.dirname(__file__), '../..', 'resources')
     script = os.path.join(resource_path, 'mnist', 'mnist.py')
     estimator = TensorFlow(entry_point=script,
@@ -31,6 +31,7 @@ def test_mnist(sagemaker_session, ecr_image, instance_type):
                            train_instance_count=1,
                            sagemaker_session=sagemaker_session,
                            image_name=ecr_image,
+                           framework_version=framework_version,
                            script_mode=True)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data'),
@@ -39,7 +40,7 @@ def test_mnist(sagemaker_session, ecr_image, instance_type):
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
-def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type):
+def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, framework_version):
     resource_path = os.path.join(os.path.dirname(__file__), '../..', 'resources')
     script = os.path.join(resource_path, 'mnist', 'mnist.py')
     estimator = TensorFlow(entry_point=script,
@@ -48,6 +49,7 @@ def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type):
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
                            image_name=ecr_image,
+                           framework_version=framework_version,
                            script_mode=True)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data'),
@@ -56,7 +58,7 @@ def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type):
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
-def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type):
+def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type, framework_version):
     resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
     script = os.path.join(resource_path, 'mnist', 'mnist_estimator.py')
     estimator = TensorFlow(entry_point=script,
@@ -66,6 +68,7 @@ def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type):
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
                            image_name=ecr_image,
+                           framework_version=framework_version,
                            script_mode=True)
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(resource_path, 'mnist', 'data-distributed'),
@@ -75,7 +78,7 @@ def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type):
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
-def test_s3_plugin(sagemaker_session, ecr_image, instance_type, region):
+def test_s3_plugin(sagemaker_session, ecr_image, instance_type, region, framework_version):
     resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
     script = os.path.join(resource_path, 'mnist', 'mnist_estimator.py')
     estimator = TensorFlow(entry_point=script,
@@ -98,6 +101,7 @@ def test_s3_plugin(sagemaker_session, ecr_image, instance_type, region):
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
                            image_name=ecr_image,
+                           framework_version=framework_version,
                            script_mode=True)
     estimator.fit('s3://sagemaker-sample-data-{}/tensorflow/mnist'.format(region),
                   job_name=unique_name_from_base('test-tf-sm-s3-mnist'))

--- a/test/integration/sagemaker/test_tuning_model_dir.py
+++ b/test/integration/sagemaker/test_tuning_model_dir.py
@@ -13,6 +13,8 @@
 from __future__ import absolute_import
 
 import os
+import random
+import time
 
 from sagemaker.tensorflow import TensorFlow
 from sagemaker.tuner import HyperparameterTuner, IntegerParameter
@@ -36,9 +38,14 @@ def test_model_dir_with_training_job_name(sagemaker_session, ecr_image, instance
                                 hyperparameter_ranges={'arbitrary_value': IntegerParameter(0, 1)},
                                 metric_definitions=[{'Name': 'accuracy', 'Regex': 'accuracy=([01])'}],
                                 max_jobs=1,
-                                max_parallel_jobs=1,
-                                base_tuning_job_name='test-tf-tuning-model-dir')
+                                max_parallel_jobs=1)
 
     # User script has logic to check for the correct model_dir
-    tuner.fit()
+    tuner.fit(job_name=_unique_job_name())
     tuner.wait()
+
+
+def _unique_job_name():
+    unique = '%04x' % random.randrange(16**4)  # 4-digit hex
+    ts = str(int(time.time()))
+    return '{}-{}-{}'.format('test-tf-model-dir', ts, unique)

--- a/test/integration/sagemaker/test_tuning_model_dir.py
+++ b/test/integration/sagemaker/test_tuning_model_dir.py
@@ -13,11 +13,11 @@
 from __future__ import absolute_import
 
 import os
-import random
-import time
 
 from sagemaker.tensorflow import TensorFlow
 from sagemaker.tuner import HyperparameterTuner, IntegerParameter
+
+from utils import unique_name_from_base
 
 
 def test_model_dir_with_training_job_name(sagemaker_session, ecr_image, instance_type, framework_version):
@@ -41,11 +41,5 @@ def test_model_dir_with_training_job_name(sagemaker_session, ecr_image, instance
                                 max_parallel_jobs=1)
 
     # User script has logic to check for the correct model_dir
-    tuner.fit(job_name=_unique_job_name())
+    tuner.fit(job_name=unique_name_from_base('test-tf-model-dir', max_length=32))
     tuner.wait()
-
-
-def _unique_job_name():
-    unique = '%04x' % random.randrange(16**4)  # 4-digit hex
-    ts = str(int(time.time()))
-    return '{}-{}-{}'.format('test-tf-model-dir', ts, unique)

--- a/test/integration/sagemaker/utils.py
+++ b/test/integration/sagemaker/utils.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import random
+import time
+
+
+def unique_name_from_base(base, max_length=63):
+    unique = '%04x' % random.randrange(16**4)  # 4-digit hex
+    ts = str(int(time.time()))
+    available_length = max_length - 2 - len(ts) - len(unique)
+    trimmed = base[:available_length]
+    return '{}-{}-{}'.format(trimmed, ts, unique)


### PR DESCRIPTION
*Description of changes:*
Running the tuning integ test for multiple images in parallel was causing name collision issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
