### PR TITLE
fix: bump sagemaker-containers version to 2.4.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
 
-    install_requires=['sagemaker-containers>=2.4.6', 'numpy', 'scipy', 'sklearn',
+    install_requires=['sagemaker-containers>=2.4.10', 'numpy', 'scipy', 'sklearn',
                       'pandas', 'Pillow', 'h5py'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest==4.4.1', 'pytest-cov', 'pytest-xdist', 'mock',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump version of sagemaker-containers to enable network isolation support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
