### PR TITLE
Update the location of latest TF 1.13 builds

### DIFF
--- a/docker/1.13.1/Dockerfile.cpu
+++ b/docker/1.13.1/Dockerfile.cpu
@@ -73,7 +73,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.U
 
 ARG framework_support_installable=sagemaker_tensorflow_container-2.0.0.tar.gz
 COPY $framework_support_installable .
-ARG TF_URL="https://s3-us-west-2.amazonaws.com/tensorflow-aws/1.13/AmazonLinux/cpu/latest-patch-s3_testcopy.patch/tensorflow-1.13.1-cp36-cp36m-linux_x86_64.whl"
+ARG TF_URL="https://tensorflow-aws.s3-us-west-2.amazonaws.com/1.13/AmazonLinux/cpu/latest-patch-latest-patch/tensorflow-1.13.1-cp36-cp36m-linux_x86_64.whl"
 
 RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
 

--- a/docker/1.13.1/Dockerfile.gpu
+++ b/docker/1.13.1/Dockerfile.gpu
@@ -105,7 +105,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.U
 
 WORKDIR /
 
-ARG TF_URL="https://s3-us-west-2.amazonaws.com/tensorflow-aws/1.13/AmazonLinux/gpu/latest-patch-s3_testcopy.patch/tensorflow-1.13.1-cp36-cp36m-linux_x86_64.whl"
+ARG TF_URL="https://tensorflow-aws.s3-us-west-2.amazonaws.com/1.13/AmazonLinux/gpu/latest-patch-latest-patch/tensorflow-1.13.1-cp36-cp36m-linux_x86_64.whl"
 
 RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
 


### PR DESCRIPTION
*Description of changes:*
The latest builds of the TF 1.13 whl files are on a different S3 bucket. Pointing TF_URL to them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
