### PR TITLE
use last legacy mode version for --framework-version test arg default

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -16,7 +16,6 @@ import logging
 import boto3
 import pytest
 from sagemaker import Session
-from sagemaker.tensorflow import TensorFlow
 
 logger = logging.getLogger(__name__)
 logging.getLogger('boto').setLevel(logging.INFO)
@@ -32,7 +31,7 @@ def pytest_addoption(parser):
     parser.addoption('--instance-type')
     parser.addoption('--accelerator-type', default=None)
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default=TensorFlow.LATEST_VERSION)
+    parser.addoption('--framework-version', default='1.12.0')
     parser.addoption('--processor', default='cpu', choices=['gpu', 'cpu'])
     parser.addoption('--tag')
 


### PR DESCRIPTION
*Description of changes:*
`sagemaker.tensorflow.TensorFlow.LATEST_VERSION` is currently 1.13.1, which is beyond what's supported for legacy mode, so the tests in this branch should no longer rely on that variable. Using the last legacy mode version seems like a reasonable default instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
