### PR TITLE
Fix horovod mnist script

### DIFF
--- a/test/resources/mnist/horovod_mnist.py
+++ b/test/resources/mnist/horovod_mnist.py
@@ -117,7 +117,7 @@ print('Test accuracy:', score[1])
 
 if hvd.rank() == 0:
     # Exports the keras model as TensorFlow Serving Saved Model
-    with tf.Session() as session:
+    with K.get_session() as session:
 
         init = tf.global_variables_initializer()
         session.run(init)


### PR DESCRIPTION
*Issue #, if available:*
TF/Keras session used incorrectly causing error:
tensorflow.python.framework.errors_impl.InvalidArgumentError: Invalid device ordinal value (1). Valid range is [0, 0].

*Description of changes:*
Use K.get_session() which is set above. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
