### PR TITLE
change: use regional endpoint for STS in builds

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -11,7 +11,7 @@ phases:
   pre_build:
     commands:
       - start-dockerd
-      - ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)
+      - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
 
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,7 @@ phases:
   pre_build:
     commands:
       - start-dockerd
-      - ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)
+      - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
       - echo 'Pull request number:' $PR_NUM '. No value means this build is not from pull request.'


### PR DESCRIPTION
related:
* https://github.com/aws/sagemaker-mxnet-serving-container/pull/76
* https://github.com/aws/sagemaker-mxnet-container/pull/113
* https://github.com/aws/sagemaker-chainer-container/pull/107
* https://github.com/aws/sagemaker-pytorch-container/pull/134
* https://github.com/aws/sagemaker-pytorch-serving-container/pull/10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
