### PR TITLE
update: Update awscli version and remove related pins

### DIFF
--- a/docker/1.15.0/py2/Dockerfile.cpu
+++ b/docker/1.15.0/py2/Dockerfile.cpu
@@ -100,9 +100,6 @@ RUN pip install --no-cache-dir -U \
     keras_preprocessing==1.1.0 \
     requests==2.22.0 \
     keras==2.3.1 \
-    # botocore requires python-dateutil<2.8.1
-    "python-dateutil<2.8.1" \
-    awscli==1.16.296 \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
@@ -111,10 +108,9 @@ RUN pip install --no-cache-dir -U \
     ${TF_URL} \
  && pip install --no-cache-dir -U \
     $FRAMEWORK_SUPPORT_INSTALLABLE \
+    awscli==1.16.314 \
  && rm -f $FRAMEWORK_SUPPORT_INSTALLABLE \
  && pip install --no-cache-dir -U \
-    # awscli requires PyYAML<5.2
-    "PyYAML<5.2" \
     horovod==0.18.2
 
 COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py

--- a/docker/1.15.0/py2/Dockerfile.gpu
+++ b/docker/1.15.0/py2/Dockerfile.gpu
@@ -133,9 +133,6 @@ RUN pip install --no-cache-dir -U \
     keras_preprocessing==1.1.0 \
     requests==2.22.0 \
     keras==2.3.1 \
-    # botocore requires python-dateutil<2.8.1
-    "python-dateutil<2.8.1" \
-    awscli==1.16.296 \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
@@ -144,13 +141,12 @@ RUN pip install --no-cache-dir -U \
     ${TF_URL} \
  && pip install --no-cache-dir -U \
     $FRAMEWORK_SUPPORT_INSTALLABLE \
+    awscli==1.16.314 \
  && rm -f $FRAMEWORK_SUPPORT_INSTALLABLE
 
 # Install Horovod, temporarily using CUDA stubs
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs \
  && HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_WITH_TENSORFLOW=1 pip install --no-cache-dir \
-    # awscli requires PyYAML<5.2
-    "PyYAML<5.2" \
     horovod==0.18.2 \
  && ldconfig
 

--- a/docker/1.15.0/py3/Dockerfile.cpu
+++ b/docker/1.15.0/py3/Dockerfile.cpu
@@ -105,7 +105,6 @@ RUN pip install --no-cache-dir -U \
     requests==2.22.0 \
     smdebug==0.4.14 \
     sagemaker-experiments==0.1.3 \
-    awscli==1.16.296 \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
@@ -119,6 +118,7 @@ RUN pip install --no-cache-dir -U \
     horovod==0.18.2 \
  && pip install --no-cache-dir -U \
     $FRAMEWORK_SUPPORT_INSTALLABLE \
+    awscli==1.16.314 \
  && rm -f $FRAMEWORK_SUPPORT_INSTALLABLE
 
 COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py

--- a/docker/1.15.0/py3/Dockerfile.cpu
+++ b/docker/1.15.0/py3/Dockerfile.cpu
@@ -88,8 +88,6 @@ RUN pip3 --no-cache-dir install --upgrade \
 RUN ln -s $(which python3) /usr/local/bin/python \
  && ln -s $(which pip3) /usr/bin/pip
 
-# install PyYAML==5.1.2 to avoid conflict with latest awscli
-# python-dateutil==2.8.0 to satisfy botocore associated with latest awscli
 RUN pip install --no-cache-dir -U \
     numpy==1.17.4 \
     scipy==1.2.2 \
@@ -100,8 +98,6 @@ RUN pip install --no-cache-dir -U \
     keras_applications==1.0.8 \
     keras_preprocessing==1.1.0 \
     keras==2.3.1 \
-    # botocore requires python-dateutil<2.8.1
-    "python-dateutil<2.8.1" \
     requests==2.22.0 \
     smdebug==0.4.14 \
     sagemaker-experiments==0.1.3 \
@@ -113,8 +109,6 @@ RUN pip install --no-cache-dir -U \
  && pip install --force-reinstall --no-cache-dir -U \
     ${TF_URL} \
  && pip install --force-reinstall --no-cache-dir -U \
-    # awscli requires PyYAML<5.2
-    "PyYAML<5.2" \
     horovod==0.18.2 \
  && pip install --no-cache-dir -U \
     $FRAMEWORK_SUPPORT_INSTALLABLE \

--- a/docker/1.15.0/py3/Dockerfile.gpu
+++ b/docker/1.15.0/py3/Dockerfile.gpu
@@ -125,8 +125,6 @@ RUN ln -s $(which python3) /usr/local/bin/python \
 
 COPY $FRAMEWORK_SUPPORT_INSTALLABLE .
 
-# install PyYAML==5.1.2 to avoid conflict with latest awscli
-# python-dateutil==2.8.0 to satisfy botocore associated with latest awscli
 RUN pip install --no-cache-dir -U \
     numpy==1.17.4 \
     scipy==1.2.2 \
@@ -138,8 +136,6 @@ RUN pip install --no-cache-dir -U \
     keras_preprocessing==1.1.0 \
     requests==2.22.0 \
     keras==2.3.1 \
-    # botocore requires python-dateutil<2.8.1
-    "python-dateutil<2.8.1" \
     smdebug==0.4.14 \
     sagemaker-experiments==0.1.3 \
     mpi4py==3.0.2 \
@@ -157,8 +153,6 @@ RUN pip install --no-cache-dir -U \
 # Install Horovod, temporarily using CUDA stubs
 RUN ldconfig /usr/local/cuda-10.0/targets/x86_64-linux/lib/stubs \
  && HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_WITH_TENSORFLOW=1 pip install --no-cache-dir \
-    # awscli requires PyYAML<5.2
-    "PyYAML<5.2" \
     horovod==0.18.2 \
  && ldconfig
 

--- a/docker/1.15.0/py3/Dockerfile.gpu
+++ b/docker/1.15.0/py3/Dockerfile.gpu
@@ -142,7 +142,6 @@ RUN pip install --no-cache-dir -U \
     "python-dateutil<2.8.1" \
     smdebug==0.4.14 \
     sagemaker-experiments==0.1.3 \
-    awscli==1.16.296 \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
@@ -152,6 +151,7 @@ RUN pip install --no-cache-dir -U \
     ${TF_URL} \
  && pip install --no-cache-dir -U \
     $FRAMEWORK_SUPPORT_INSTALLABLE \
+    awscli==1.16.314 \
  && rm -f $FRAMEWORK_SUPPORT_INSTALLABLE
 
 # Install Horovod, temporarily using CUDA stubs

--- a/setup.py
+++ b/setup.py
@@ -53,13 +53,13 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
 
-    install_requires=['sagemaker-containers>=2.4.6', 'numpy', 'scipy', 'sklearn',
+    install_requires=['sagemaker-containers>=2.6.2', 'numpy', 'scipy', 'sklearn',
                       'pandas', 'Pillow', 'h5py'],
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',
-                 'sagemaker==1.19.1', 'tensorflow<2.0', 'docker-compose', 'boto3==1.10.32',
-                 'six==1.13.0', 'python-dateutil>=2.1,<2.8.1', 'botocore==1.13.32',
-                 'requests-mock', 'awscli==1.16.296'],
+                 'sagemaker==1.50.1', 'tensorflow<2.0', 'docker-compose', 'boto3==1.10.50',
+                 'six==1.13.0', 'python-dateutil>=2.1,<2.8.1', 'botocore==1.13.50',
+                 'requests-mock', 'awscli==1.16.314'],
         'benchmark': ['click']
     },
 )


### PR DESCRIPTION
*Description of changes:*
- Updated awscli from 1.16.296 to 1.16.314
- Previously pinned python-dateutils and pyyaml have been unpinned, as awscli is not dependent on it now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
