### PR TITLE
documentation: Add link to TF 2.0 branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,10 @@ The Docker images are built from the Dockerfiles specified in
 The Docker files are grouped based on TensorFlow version and separated
 based on Python version and processor type.
 
+The Docker files for TensorFlow 2.0 are available in the
+`tf-2 <https://github.com/aws/sagemaker-tensorflow-container/tree/tf-2>`__ branch, in
+`docker/2.0.0/ <https://github.com/aws/sagemaker-tensorflow-container/tree/tf-2/docker>`__.
+
 The Docker images, used to run training & inference jobs, are built from
 both corresponding "base" and "final" Dockerfiles.
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ based on Python version and processor type.
 
 The Docker files for TensorFlow 2.0 are available in the
 `tf-2 <https://github.com/aws/sagemaker-tensorflow-container/tree/tf-2>`__ branch, in
-`docker/2.0.0/ <https://github.com/aws/sagemaker-tensorflow-container/tree/tf-2/docker>`__.
+`docker/2.0.0/ <https://github.com/aws/sagemaker-tensorflow-container/tree/tf-2/docker/2.0.0>`__.
 
 The Docker images, used to run training & inference jobs, are built from
 both corresponding "base" and "final" Dockerfiles.


### PR DESCRIPTION
*Description of changes:*
Add a link to TF 2.0 branch, and provide link to TF 2.0 training dockerfiles

Can be seen at:
https://github.com/saimidu/sagemaker-tensorflow-container/tree/tf2.0_readme#building-your-image

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
