### PR TITLE
Fix location for integration tests and conftest.py in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,7 +207,7 @@ Running integration tests require `Docker <https://www.docker.com/>`__ and `AWS
 credentials <https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html>`__,
 as the integration tests make calls to a couple AWS services. The integration and functional
 tests require configurations specified within their respective
-`conftest.py <https://github.com/aws/sagemaker-tensorflow-containers/blob/master/test/integ/conftest.py>`__.
+`conftest.py <https://github.com/aws/sagemaker-tensorflow-containers/blob/master/test/integration/conftest.py>`__.Make sure to update the account-id and region at a minimum.
 
 Integration tests on GPU require `Nvidia-Docker <https://github.com/NVIDIA/nvidia-docker>`__.
 
@@ -222,18 +222,18 @@ If you want to run local integration tests, then use:
 
     # Required arguments for integration tests are found in test/integ/conftest.py
 
-    pytest test/integ --docker-base-name <your_docker_image> \
-                      --tag <your_docker_image_tag> \
-                      --framework-version <tensorflow_version> \
-                      --processor <cpu_or_gpu>
+    pytest test/integration --docker-base-name <your_docker_image> \
+                            --tag <your_docker_image_tag> \
+                            --framework-version <tensorflow_version> \
+                            --processor <cpu_or_gpu>
 
 ::
 
     # Example
-    pytest test/integ --docker-base-name preprod-tensorflow \
-                      --tag 1.0 \
-                      --framework-version 1.4.1 \
-                      --processor cpu
+    pytest test/integration --docker-base-name preprod-tensorflow \
+                            --tag 1.0 \
+                            --framework-version 1.4.1 \
+                            --processor cpu
 
 Functional Tests
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixed the location for integration tests and conftest.py

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Also, Contributing.md link in the documentation is broken. - Need to add a contributing.md