### PR TITLE
fix: remove sagemaker_experiments from mnist script

### DIFF
--- a/test/resources/mnist/mnist.py
+++ b/test/resources/mnist/mnist.py
@@ -35,18 +35,6 @@ def _load_testing_data(base_dir):
     return x_test, y_test
 
 
-def assert_can_track_sagemaker_experiments():
-    in_sagemaker_training = 'TRAINING_JOB_ARN' in os.environ
-    in_python_three = sys.version_info[0] == 3
-
-    if in_sagemaker_training and in_python_three:
-        import smexperiments.tracker
-
-        with smexperiments.tracker.Tracker.load() as tracker:
-            tracker.log_parameter('param', 1)
-            tracker.log_metric('metric', 1.0)
-
-
 args, unknown = _parse_args()
 
 model = tf.keras.models.Sequential([
@@ -66,4 +54,3 @@ model.evaluate(x_test, y_test)
 
 if args.current_host == args.hosts[0]:
     model.save(os.path.join('/opt/ml/model', 'my_model.h5'))
-    assert_can_track_sagemaker_experiments()


### PR DESCRIPTION
*Issue #, if available:*
sagemaker-experirments not installed in 2.0 container, causing test failures.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
