### PR TITLE
Add default timeout

### DIFF
--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -19,6 +19,7 @@ logging.getLogger('boto3').setLevel(logging.INFO)
 logging.getLogger('botocore').setLevel(logging.INFO)
 
 RESOURCE_PATH = os.path.join(os.path.dirname(__file__), '..', 'resources')
+DEFAULT_TIMEOUT = 120
 
 # these regions have some p2 and p3 instances, but not enough for automated testing
 NO_P2_REGIONS = [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The integration tests module does not have a DEFAULT_TIMEOUT parameter referenced in the test_experiments.py file. This PR adds the parameter. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
