### PR TITLE
Added marker to skip distributed unit tests

### DIFF
--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -99,6 +99,7 @@ def test_train_horovod(run_module, single_machine_training_env):
                                   runner=runner.MPIRunnerType)
 
 
+@pytest.mark.skip_on_pipeline
 @pytest.mark.skipif(sys.version_info.major != 3,
                     reason="Skip this for python 2 because of dict key order mismatch")
 @patch('tensorflow.train.ClusterSpec')
@@ -129,6 +130,7 @@ def test_train_distributed_master(run, tf_server, cluster_spec, distributed_trai
                            {'TF_CONFIG': tf_config})
 
 
+@pytest.mark.skip_on_pipeline
 @pytest.mark.skipif(sys.version_info.major != 3,
                     reason="Skip this for python 2 because of dict key order mismatch")
 @patch('tensorflow.train.ClusterSpec')


### PR DESCRIPTION
*Issue #, if available:*
The test_distributed_master and test_dsitrbuted_worker tests do not work on certain environments. 

*Description of changes:*
This PR adds a marker to skip the tests in unsupported environments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
