### PR TITLE
 breaking: Replace sagemaker-containers with sagemaker-training

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
 
-    install_requires=['sagemaker-containers>=2.6.2', 'numpy', 'scipy', 'sklearn',
+    install_requires=['sagemaker-training>=3.5.0', 'numpy', 'scipy', 'sklearn',
                       'pandas', 'Pillow', 'h5py'],
     extras_require={
         'test': test_dependencies,

--- a/src/sagemaker_tensorflow_container/training.py
+++ b/src/sagemaker_tensorflow_container/training.py
@@ -154,7 +154,10 @@ def train(env, cmd_args):
         else:
             runner_type = runner.ProcessRunnerType
 
-        entry_point.run(env.module_dir, env.user_entry_point, cmd_args, env.to_env_vars(),
+        entry_point.run(env.module_dir,
+                        env.user_entry_point,
+                        cmd_args,
+                        env.to_env_vars(),
                         runner_type=runner_type)
 
 

--- a/src/sagemaker_tensorflow_container/training.py
+++ b/src/sagemaker_tensorflow_container/training.py
@@ -19,7 +19,7 @@ import os
 import subprocess
 import time
 
-import sagemaker_containers.beta.framework as framework
+from sagemaker_training import entry_point, environment, mapping, runner
 import tensorflow as tf
 
 from sagemaker_tensorflow_container import s3_utils
@@ -109,7 +109,7 @@ def _run_worker(env, cmd_args, tf_config):
     env_vars = env.to_env_vars()
     env_vars['TF_CONFIG'] = json.dumps(tf_config)
 
-    framework.entry_point.run(env.module_dir, env.user_entry_point, cmd_args, env_vars)
+    entry_point.run(env.module_dir, env.user_entry_point, cmd_args, env_vars)
 
 
 def _wait_until_master_is_down(master):
@@ -128,7 +128,7 @@ def train(env, cmd_args):
     """Get training job environment from env and run the training job.
 
     Args:
-        env (sagemaker_containers.beta.framework.env.TrainingEnv): Instance of TrainingEnv class
+        env (sagemaker_training.env.TrainingEnv): Instance of TrainingEnv class
     """
     parameter_server_enabled = env.additional_framework_parameters.get(
         SAGEMAKER_PARAMETER_SERVER_ENABLED, False)
@@ -150,12 +150,12 @@ def train(env, cmd_args):
         mpi_enabled = env.additional_framework_parameters.get('sagemaker_mpi_enabled')
 
         if mpi_enabled:
-            runner_type = framework.runner.MPIRunnerType
+            runner_type = runner.MPIRunnerType
         else:
-            runner_type = framework.runner.ProcessRunnerType
+            runner_type = runner.ProcessRunnerType
 
-        framework.entry_point.run(env.module_dir, env.user_entry_point, cmd_args, env.to_env_vars(),
-                                  runner=runner_type)
+        entry_point.run(env.module_dir, env.user_entry_point, cmd_args, env.to_env_vars(),
+                        runner_type=runner_type)
 
 
 def _log_model_missing_warning(model_dir):
@@ -195,8 +195,8 @@ def _model_dir_with_training_job(model_dir, job_name):
 def main():
     """Training entry point
     """
-    hyperparameters = framework.env.read_hyperparameters()
-    env = framework.training_env(hyperparameters=hyperparameters)
+    hyperparameters = environment.read_hyperparameters()
+    env = environment.Environment(hyperparameters=hyperparameters)
 
     user_hyperparameters = env.hyperparameters
 
@@ -208,5 +208,5 @@ def main():
         user_hyperparameters['model_dir'] = model_dir
 
     s3_utils.configure(user_hyperparameters.get('model_dir'), os.environ.get('SAGEMAKER_REGION'))
-    train(env, framework.mapping.to_cmd_args(user_hyperparameters))
+    train(env, mapping.to_cmd_args(user_hyperparameters))
     _log_model_missing_warning(MODEL_DIR)

--- a/src/sagemaker_tensorflow_container/training.py
+++ b/src/sagemaker_tensorflow_container/training.py
@@ -128,7 +128,7 @@ def train(env, cmd_args):
     """Get training job environment from env and run the training job.
 
     Args:
-        env (sagemaker_training.env.TrainingEnv): Instance of TrainingEnv class
+        env (sagemaker_training.environment.Environment): Instance of Environment class
     """
     parameter_server_enabled = env.additional_framework_parameters.get(
         SAGEMAKER_PARAMETER_SERVER_ENABLED, False)

--- a/test-toolkit/unit/test_training.py
+++ b/test-toolkit/unit/test_training.py
@@ -17,7 +17,7 @@ import sys
 
 from mock import MagicMock, patch
 import pytest
-from sagemaker_containers.beta.framework import runner
+from sagemaker_training import runner
 import tensorflow as tf
 
 from sagemaker_tensorflow_container import training
@@ -81,22 +81,22 @@ def test_is_host_master():
     assert training._is_host_master(HOST_LIST, 'somehost') is False
 
 
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 def test_single_machine(run_module, single_machine_training_env):
     training.train(single_machine_training_env, MODEL_DIR_CMD_LIST)
     run_module.assert_called_with(MODULE_DIR, MODULE_NAME, MODEL_DIR_CMD_LIST,
                                   single_machine_training_env.to_env_vars(),
-                                  runner=runner.ProcessRunnerType)
+                                  runner_type=runner.ProcessRunnerType)
 
 
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 def test_train_horovod(run_module, single_machine_training_env):
     single_machine_training_env.additional_framework_parameters['sagemaker_mpi_enabled'] = True
 
     training.train(single_machine_training_env, MODEL_DIR_CMD_LIST)
     run_module.assert_called_with(MODULE_DIR, MODULE_NAME, MODEL_DIR_CMD_LIST,
                                   single_machine_training_env.to_env_vars(),
-                                  runner=runner.MPIRunnerType)
+                                  runner_type=runner.MPIRunnerType)
 
 
 @pytest.mark.skip_on_pipeline
@@ -104,7 +104,7 @@ def test_train_horovod(run_module, single_machine_training_env):
                     reason="Skip this for python 2 because of dict key order mismatch")
 @patch('tensorflow.train.ClusterSpec')
 @patch('tensorflow.distribute.Server')
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 @patch('multiprocessing.Process', lambda target: target())
 @patch('time.sleep', MagicMock())
 def test_train_distributed_master(run, tf_server, cluster_spec, distributed_training_env):
@@ -135,7 +135,7 @@ def test_train_distributed_master(run, tf_server, cluster_spec, distributed_trai
                     reason="Skip this for python 2 because of dict key order mismatch")
 @patch('tensorflow.train.ClusterSpec')
 @patch('tensorflow.distribute.Server')
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 @patch('multiprocessing.Process', lambda target: target())
 @patch('time.sleep', MagicMock())
 def test_train_distributed_worker(run, tf_server, cluster_spec, distributed_training_env):
@@ -163,7 +163,7 @@ def test_train_distributed_worker(run, tf_server, cluster_spec, distributed_trai
                            {'TF_CONFIG': tf_config})
 
 
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 def test_train_distributed_no_ps(run, distributed_training_env):
     distributed_training_env.additional_framework_parameters[
         training.SAGEMAKER_PARAMETER_SERVER_ENABLED] = False
@@ -171,7 +171,7 @@ def test_train_distributed_no_ps(run, distributed_training_env):
     training.train(distributed_training_env, MODEL_DIR_CMD_LIST)
 
     run.assert_called_with(MODULE_DIR, MODULE_NAME, MODEL_DIR_CMD_LIST,
-                           distributed_training_env.to_env_vars(), runner=runner.ProcessRunnerType)
+                           distributed_training_env.to_env_vars(), runner_type=runner.ProcessRunnerType)
 
 
 def test_build_tf_config():
@@ -241,8 +241,8 @@ def test_log_model_missing_warning_correct(logger):
 @patch('sagemaker_tensorflow_container.training.logger')
 @patch('sagemaker_tensorflow_container.training.train')
 @patch('logging.Logger.setLevel')
-@patch('sagemaker_containers.beta.framework.training_env')
-@patch('sagemaker_containers.beta.framework.env.read_hyperparameters', return_value={})
+@patch('sagemaker_training.environment.Environment')
+@patch('sagemaker_training.environment.read_hyperparameters', return_value={})
 @patch('sagemaker_tensorflow_container.s3_utils.configure')
 def test_main(configure_s3_env, read_hyperparameters, training_env,
               set_level, train, logger, single_machine_training_env):
@@ -258,8 +258,8 @@ def test_main(configure_s3_env, read_hyperparameters, training_env,
 @patch('sagemaker_tensorflow_container.training.logger')
 @patch('sagemaker_tensorflow_container.training.train')
 @patch('logging.Logger.setLevel')
-@patch('sagemaker_containers.beta.framework.training_env')
-@patch('sagemaker_containers.beta.framework.env.read_hyperparameters', return_value={'model_dir': MODEL_DIR})
+@patch('sagemaker_training.environment.Environment')
+@patch('sagemaker_training.environment.read_hyperparameters', return_value={'model_dir': MODEL_DIR})
 @patch('sagemaker_tensorflow_container.s3_utils.configure')
 def test_main_simple_training_model_dir(configure_s3_env, read_hyperparameters, training_env,
                                         set_level, train, logger, single_machine_training_env):
@@ -272,9 +272,9 @@ def test_main_simple_training_model_dir(configure_s3_env, read_hyperparameters, 
 @patch('sagemaker_tensorflow_container.training.logger')
 @patch('sagemaker_tensorflow_container.training.train')
 @patch('logging.Logger.setLevel')
-@patch('sagemaker_containers.beta.framework.training_env')
-@patch('sagemaker_containers.beta.framework.env.read_hyperparameters', return_value={'model_dir': MODEL_DIR,
-                                                                                     '_tuning_objective_metric': 'auc'})
+@patch('sagemaker_training.environment.Environment')
+@patch('sagemaker_training.environment.read_hyperparameters', return_value={'model_dir': MODEL_DIR,
+                                                                            '_tuning_objective_metric': 'auc'})
 @patch('sagemaker_tensorflow_container.s3_utils.configure')
 def test_main_tuning_model_dir(configure_s3_env, read_hyperparameters, training_env,
                                set_level, train, logger, single_machine_training_env):
@@ -288,9 +288,9 @@ def test_main_tuning_model_dir(configure_s3_env, read_hyperparameters, training_
 @patch('sagemaker_tensorflow_container.training.logger')
 @patch('sagemaker_tensorflow_container.training.train')
 @patch('logging.Logger.setLevel')
-@patch('sagemaker_containers.beta.framework.training_env')
-@patch('sagemaker_containers.beta.framework.env.read_hyperparameters', return_value={'model_dir': '/opt/ml/model',
-                                                                                     '_tuning_objective_metric': 'auc'})
+@patch('sagemaker_training.environment.Environment')
+@patch('sagemaker_training.environment.read_hyperparameters', return_value={'model_dir': '/opt/ml/model',
+                                                                            '_tuning_objective_metric': 'auc'})
 @patch('sagemaker_tensorflow_container.s3_utils.configure')
 def test_main_tuning_mpi_model_dir(configure_s3_env, read_hyperparameters, training_env,
                                    set_level, train, logger, single_machine_training_env):

--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -17,7 +17,7 @@ import sys
 
 from mock import MagicMock, patch
 import pytest
-from sagemaker_containers.beta.framework import runner
+from sagemaker_training import runner
 import tensorflow as tf
 
 from sagemaker_tensorflow_container import training
@@ -81,22 +81,22 @@ def test_is_host_master():
     assert training._is_host_master(HOST_LIST, 'somehost') is False
 
 
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 def test_single_machine(run_module, single_machine_training_env):
     training.train(single_machine_training_env, MODEL_DIR_CMD_LIST)
     run_module.assert_called_with(MODULE_DIR, MODULE_NAME, MODEL_DIR_CMD_LIST,
                                   single_machine_training_env.to_env_vars(),
-                                  runner=runner.ProcessRunnerType)
+                                  runner_type=runner.ProcessRunnerType)
 
 
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 def test_train_horovod(run_module, single_machine_training_env):
     single_machine_training_env.additional_framework_parameters['sagemaker_mpi_enabled'] = True
 
     training.train(single_machine_training_env, MODEL_DIR_CMD_LIST)
     run_module.assert_called_with(MODULE_DIR, MODULE_NAME, MODEL_DIR_CMD_LIST,
                                   single_machine_training_env.to_env_vars(),
-                                  runner=runner.MPIRunnerType)
+                                  runner_type=runner.MPIRunnerType)
 
 
 @pytest.mark.skip_on_pipeline
@@ -104,7 +104,7 @@ def test_train_horovod(run_module, single_machine_training_env):
                     reason="Skip this for python 2 because of dict key order mismatch")
 @patch('tensorflow.train.ClusterSpec')
 @patch('tensorflow.distribute.Server')
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 @patch('multiprocessing.Process', lambda target: target())
 @patch('time.sleep', MagicMock())
 def test_train_distributed_master(run, tf_server, cluster_spec, distributed_training_env):
@@ -135,7 +135,7 @@ def test_train_distributed_master(run, tf_server, cluster_spec, distributed_trai
                     reason="Skip this for python 2 because of dict key order mismatch")
 @patch('tensorflow.train.ClusterSpec')
 @patch('tensorflow.distribute.Server')
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 @patch('multiprocessing.Process', lambda target: target())
 @patch('time.sleep', MagicMock())
 def test_train_distributed_worker(run, tf_server, cluster_spec, distributed_training_env):
@@ -163,7 +163,7 @@ def test_train_distributed_worker(run, tf_server, cluster_spec, distributed_trai
                            {'TF_CONFIG': tf_config})
 
 
-@patch('sagemaker_containers.beta.framework.entry_point.run')
+@patch('sagemaker_training.entry_point.run')
 def test_train_distributed_no_ps(run, distributed_training_env):
     distributed_training_env.additional_framework_parameters[
         training.SAGEMAKER_PARAMETER_SERVER_ENABLED] = False
@@ -171,7 +171,7 @@ def test_train_distributed_no_ps(run, distributed_training_env):
     training.train(distributed_training_env, MODEL_DIR_CMD_LIST)
 
     run.assert_called_with(MODULE_DIR, MODULE_NAME, MODEL_DIR_CMD_LIST,
-                           distributed_training_env.to_env_vars(), runner=runner.ProcessRunnerType)
+                           distributed_training_env.to_env_vars(), runner_type=runner.ProcessRunnerType)
 
 
 def test_build_tf_config():
@@ -241,8 +241,8 @@ def test_log_model_missing_warning_correct(logger):
 @patch('sagemaker_tensorflow_container.training.logger')
 @patch('sagemaker_tensorflow_container.training.train')
 @patch('logging.Logger.setLevel')
-@patch('sagemaker_containers.beta.framework.training_env')
-@patch('sagemaker_containers.beta.framework.env.read_hyperparameters', return_value={})
+@patch('sagemaker_training.environment.Environment')
+@patch('sagemaker_training.environment.read_hyperparameters', return_value={})
 @patch('sagemaker_tensorflow_container.s3_utils.configure')
 def test_main(configure_s3_env, read_hyperparameters, training_env,
               set_level, train, logger, single_machine_training_env):
@@ -258,8 +258,8 @@ def test_main(configure_s3_env, read_hyperparameters, training_env,
 @patch('sagemaker_tensorflow_container.training.logger')
 @patch('sagemaker_tensorflow_container.training.train')
 @patch('logging.Logger.setLevel')
-@patch('sagemaker_containers.beta.framework.training_env')
-@patch('sagemaker_containers.beta.framework.env.read_hyperparameters', return_value={'model_dir': MODEL_DIR})
+@patch('sagemaker_training.environment.Environment')
+@patch('sagemaker_training.environment.read_hyperparameters', return_value={'model_dir': MODEL_DIR})
 @patch('sagemaker_tensorflow_container.s3_utils.configure')
 def test_main_simple_training_model_dir(configure_s3_env, read_hyperparameters, training_env,
                                         set_level, train, logger, single_machine_training_env):
@@ -272,9 +272,9 @@ def test_main_simple_training_model_dir(configure_s3_env, read_hyperparameters, 
 @patch('sagemaker_tensorflow_container.training.logger')
 @patch('sagemaker_tensorflow_container.training.train')
 @patch('logging.Logger.setLevel')
-@patch('sagemaker_containers.beta.framework.training_env')
-@patch('sagemaker_containers.beta.framework.env.read_hyperparameters', return_value={'model_dir': MODEL_DIR,
-                                                                                     '_tuning_objective_metric': 'auc'})
+@patch('sagemaker_training.environment.Environment')
+@patch('sagemaker_training.environment.read_hyperparameters', return_value={'model_dir': MODEL_DIR,
+                                                                            '_tuning_objective_metric': 'auc'})
 @patch('sagemaker_tensorflow_container.s3_utils.configure')
 def test_main_tuning_model_dir(configure_s3_env, read_hyperparameters, training_env,
                                set_level, train, logger, single_machine_training_env):
@@ -288,9 +288,9 @@ def test_main_tuning_model_dir(configure_s3_env, read_hyperparameters, training_
 @patch('sagemaker_tensorflow_container.training.logger')
 @patch('sagemaker_tensorflow_container.training.train')
 @patch('logging.Logger.setLevel')
-@patch('sagemaker_containers.beta.framework.training_env')
-@patch('sagemaker_containers.beta.framework.env.read_hyperparameters', return_value={'model_dir': '/opt/ml/model',
-                                                                                     '_tuning_objective_metric': 'auc'})
+@patch('sagemaker_training.environment.Environment')
+@patch('sagemaker_training.environment.read_hyperparameters', return_value={'model_dir': '/opt/ml/model',
+                                                                            '_tuning_objective_metric': 'auc'})
 @patch('sagemaker_tensorflow_container.s3_utils.configure')
 def test_main_tuning_mpi_model_dir(configure_s3_env, read_hyperparameters, training_env,
                                    set_level, train, logger, single_machine_training_env):

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,6 @@ passenv =
 commands =
     coverage run --rcfile .coveragerc_{envname} --source sagemaker_tensorflow_container -m py.test {posargs}
     {env:IGNORE_COVERAGE:} coverage report --include *sagemaker_tensorflow_container* --show-missing
-deps = sagemaker-containers
 extras = test
 
 [testenv:flake8]


### PR DESCRIPTION
*Description of changes:*
This PR replaces the deprecated [sagemaker-containers](https://github.com/aws/sagemaker-containers) package with the new [sagemaker-training](https://github.com/aws/sagemaker-training-toolkit) package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
