### PR TITLE
remove sagemaker, keras pks in py37 docker files

### DIFF
--- a/docker/1.15.2/py37/Dockerfile.cpu
+++ b/docker/1.15.2/py37/Dockerfile.cpu
@@ -113,11 +113,8 @@ RUN ${PIP} install --no-cache-dir -U \
     pandas==0.24.2 \
     Pillow==7.0.0 \
     h5py==2.10.0 \
-    keras_applications==1.0.8 \
-    keras_preprocessing==1.1.0 \
     requests==2.22.0 \
     smdebug==0.7.2 \
-    sagemaker==1.56.1 \
     sagemaker-experiments==0.1.7 \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \

--- a/docker/1.15.2/py37/Dockerfile.gpu
+++ b/docker/1.15.2/py37/Dockerfile.gpu
@@ -150,11 +150,8 @@ RUN ${PIP} install --no-cache-dir -U \
     pandas==0.24.2 \
     Pillow==7.0.0 \
     h5py==2.10.0 \
-    keras_applications==1.0.8 \
-    keras_preprocessing==1.1.0 \
     requests==2.22.0 \
     smdebug==0.7.2 \
-    sagemaker==1.56.1 \
     sagemaker-experiments==0.1.7 \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \


### PR DESCRIPTION
*Description of changes:*
1. remove keras_applications, keras_preprocessing
2. remove sagemaker package in the pydocker files (doesn't support py3.7 yet)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
