### PR TITLE
Install nginx for SageMaker endpoint deployment

### DIFF
--- a/docker/1.15.2/py3/Dockerfile.cpu
+++ b/docker/1.15.2/py3/Dockerfile.cpu
@@ -39,6 +39,7 @@ RUN apt-get update \
     wget \
     vim \
     zlib1g-dev \
+    nginx \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Open MPI


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I tried to use a tensorflow container for Py3 CPU framework_version 1.15.2 to deploy a model to SageMaker endpoint, but encountered the following error on CloudWatch:

`FileNotFoundError: [Errno 2] No such file or directory: 'nginx': 'nginx'`

Seem like the Dockerfile need to install `nginx`. I gave it a try and it worked!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
