### PR TITLE
fix: bump version of sagemaker-training for script entry point fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
 
-    install_requires=['sagemaker-training>=3.5.1', 'numpy', 'scipy', 'sklearn',
+    install_requires=['sagemaker-training>=3.5.2', 'numpy', 'scipy', 'sklearn',
                       'pandas', 'Pillow', 'h5py'],
     extras_require={
         'test': test_dependencies,


### PR DESCRIPTION
*Description of changes:*
Consuming the fix from https://github.com/aws/sagemaker-training-toolkit/pull/64


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
