### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,17 @@ Tagging scheme is based on <tensorflow_version>-<processor>-<python_version>. (e
 All "final" Dockerfiles build images using base images that use the tagging scheme
 above.
 
+Before building these images, you need to have a pip-installable binary of this repository saved locally. To create the SageMaker Tensorflow Container Python package:
+
+::
+    # Create the binary
+    git clone https://github.com/aws/sagemaker-tensorflow-container.git
+    cd sagemaker-tensorflow-container
+    python setup.py sdist
+    cp dist/sagemaker_tensorflow_training*.tar.gz docker/<tensorflow_version>/sagemaker_tensorflow_training.tar.gz
+
+Once you have copied the tensorflow_training.tar.gz to the desired location [same directory as the Dockerfile], you can then build the image.
+
 If you want to build your "base" Docker image, then use:
 
 ::


### PR DESCRIPTION
Issue #, if available: aws#248

Description of changes:

Fixes the issue when building docker image
For example:
When building 1.15.0 tensorflow

$ docker build -t preprod-tensorflow:1.15.0-gpu-py3 --build-arg py_version=3 --build-arg framework_installable=tensorflow_gpu-1.15.0-cp36-cp36m-manylinux2010_x86_64.whl -f Dockerfile.gpu .

Following error pops up:

Step 26/35 : COPY $FRAMEWORK_SUPPORT_INSTALLABLE .
COPY failed: no source files were specified

Change

Adds the commands to create pip-installable binary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.